### PR TITLE
Add Det/DETai split navigation section to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Footer from "../components/layout/Footer";
 import Header from "../components/layout/Header";
 import Core from "../components/sections/Core";
 import DetToDetaiBridge from "../components/sections/DetToDetaiBridge";
+import DetDetaiSplit from "../components/sections/DetDetaiSplit";
 import Hero from "../components/sections/Hero";
 import Mission from "../components/sections/Mission";
 import Projects from "../components/sections/Projects";
@@ -13,6 +14,7 @@ export default function Page() {
       <main className="flex flex-1 flex-col gap-0">
         <Hero />
         <DetToDetaiBridge />
+        <DetDetaiSplit />
         <Projects />
         <Core />
         <Mission />

--- a/components/sections/DetDetaiSplit.tsx
+++ b/components/sections/DetDetaiSplit.tsx
@@ -1,0 +1,27 @@
+export default function DetDetaiSplit() {
+  return (
+    <section className="w-full bg-white">
+      <div className="mx-auto w-full max-w-5xl px-4 py-12 md:py-16">
+        <div className="flex flex-col items-center gap-6 text-center">
+          <h2 className="text-xl font-semibold leading-tight tracking-tight text-gray-900 md:text-2xl">
+            Выберите направление
+          </h2>
+          <div className="flex w-full flex-col gap-4 md:flex-row md:items-center md:justify-center md:gap-6">
+            <a
+              className="flex w-full flex-1 items-center justify-center px-6 py-4 text-base font-semibold text-gray-900 rounded-lg border border-gray-200 bg-white shadow-sm transition hover:border-gray-300 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
+              href="/det"
+            >
+              Перейти к DET
+            </a>
+            <a
+              className="flex w-full flex-1 items-center justify-center px-6 py-4 text-base font-semibold text-gray-900 rounded-lg border border-gray-200 bg-white shadow-sm transition hover:border-gray-300 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
+              href="/detai"
+            >
+              Перейти к DETai
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a DetDetaiSplit homepage section that provides clear navigation to DET and DETai directions
- style the buttons to match existing Tailwind visuals with desktop row and mobile column layouts
- place the section after DetToDetaiBridge on the main page

## Testing
- npm run lint *(fails: repository does not contain a package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc64e456c8321b1e30caa586ebe41)