### PR TITLE
Обновить тёмный фон секций

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extend: {
       colors: {
         basic: {
-          dark: "#0B0B10",
+          dark: "#121417",
           light: "#F6F1E9",
         },
         gold: {


### PR DESCRIPTION
## Кратко
- ✨ Заменён токен тёмного фона basic.dark на #121417, чтобы смягчить фон всех секций с `bg-basic-dark`.

## Тесты
- ⚠️ npm run lint (остановлено из-за интерактивного запроса конфигурации)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f46a21724832187022921395d225d)