### PR TITLE
Перевод палитры gold на смысловые accent-токены

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,16 +1,16 @@
 export default function Footer() {
   return (
-    <footer className="w-full border-t border-gold-primary/30 bg-basic-light text-basic-dark">
+    <footer className="w-full border-t border-accent-primary/30 bg-basic-light text-basic-dark">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-4 py-6 text-sm md:flex-row md:items-center md:justify-between">
         <div className="font-serif font-semibold">DETai</div>
         <div className="flex flex-wrap items-center gap-4 font-sans font-medium">
-          <a className="hover:text-gold-primary" href="#projects">
+          <a className="hover:text-accent-primary" href="#projects">
             Проекты
           </a>
-          <a className="hover:text-gold-primary" href="#fundament-det">
+          <a className="hover:text-accent-primary" href="#fundament-det">
             Ядро DET
           </a>
-          <a className="hover:text-gold-primary" href="#mission">
+          <a className="hover:text-accent-primary" href="#mission">
             Миссия
           </a>
         </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,19 +1,19 @@
 export default function Header() {
   return (
-    <header className="w-full border-b border-gold-primary/30 bg-basic-light text-basic-dark">
+    <header className="w-full border-b border-accent-primary/30 bg-basic-light text-basic-dark">
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
         <div className="text-lg font-serif font-semibold tracking-tight">DETai</div>
         <nav className="flex items-center gap-4 text-sm font-sans font-medium">
-          <a className="hover:text-gold-primary" href="#hero">
+          <a className="hover:text-accent-primary" href="#hero">
             Главная
           </a>
-          <a className="hover:text-gold-primary" href="#projects">
+          <a className="hover:text-accent-primary" href="#projects">
             Проекты
           </a>
-          <a className="hover:text-gold-primary" href="#fundament-det">
+          <a className="hover:text-accent-primary" href="#fundament-det">
             Ядро DET
           </a>
-          <a className="hover:text-gold-primary" href="#mission">
+          <a className="hover:text-accent-primary" href="#mission">
             Миссия
           </a>
         </nav>

--- a/components/sections/AudienceSection.tsx
+++ b/components/sections/AudienceSection.tsx
@@ -40,7 +40,7 @@ export default function AudienceSection() {
         {audienceCards.map((card) => (
           <div
             key={card.title}
-            className="flex h-full flex-col gap-3 p-6 text-basic-dark rounded-xl border border-gold-primary/30 bg-gold-soft shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-gold-primary hover:shadow-lg"
+            className="flex h-full flex-col gap-3 p-6 text-basic-dark rounded-xl border border-accent-primary/30 bg-accent-soft shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg"
           >
             <h3 className="text-xl font-serif font-semibold leading-snug text-basic-dark md:text-2xl">{card.title}</h3>
             <p className="text-sm leading-relaxed text-basic-dark md:text-base">{card.description}</p>

--- a/components/sections/DetToDetaiBridge.tsx
+++ b/components/sections/DetToDetaiBridge.tsx
@@ -8,7 +8,7 @@ export default function DetToDetaiBridge() {
         <Heading level={2} color="soft">
           DET ↔ DETai
         </Heading>
-        <p className="max-w-5xl text-lg leading-relaxed text-gold-soft md:text-xl">
+        <p className="max-w-5xl text-lg leading-relaxed text-accent-soft md:text-xl">
           Диалектически-экзистенциальная терапия (DET) — это культура понимания человека, выросшая из экзистенциально-гуманистической
           традиции и опирающаяся на диалектическое видение внутренней динамики личности. DET не конкурирует с существующими школами,
           а создаёт ценностную и диалоговую рамку, в которой могут работать разные подходы и методы.

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
             <br />
             Новый формат психотерапии
           </Heading>
-          <p className="max-w-2xl text-lg leading-relaxed text-gold-soft md:text-xl">
+          <p className="max-w-2xl text-lg leading-relaxed text-accent-soft md:text-xl">
             Диалектически-экзистенциальная терапия — это культура понимания человека. DETai — это технологическая экосистема,
             включающая продукты, интерфейсы и AI-инструменты, которые воплощают культуру DET в прикладных и ежедневных формах —
             доступных как клиентам, так и психотерапевтам.

--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -8,7 +8,7 @@ export default function Mission() {
         <Heading level={2} color="soft">
           Наша миссия
         </Heading>
-        <p className="max-w-4xl text-base leading-relaxed text-gold-soft md:text-lg">
+        <p className="max-w-4xl text-base leading-relaxed text-accent-soft md:text-lg">
           Создать новую терапевтическую логику, которая объединяет глубину экзистенциальной психологии и возможности современного
           интеллекта — человеческого и искусственного. DET и DETai — это путь к осмысленным инструментам, которые помогают людям
           понимать себя и развиваться.

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -47,7 +47,7 @@ export default function Projects() {
         {projects.map((project) => (
           <a
             key={project.name}
-            className="group flex h-full flex-col gap-2 p-5 text-basic-dark rounded-lg border border-gold-primary/30 bg-gold-soft shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-gold-primary hover:shadow-lg"
+            className="group flex h-full flex-col gap-2 p-5 text-basic-dark rounded-lg border border-accent-primary/30 bg-accent-soft shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg"
             href={project.href}
           >
             <div className="flex items-center gap-3 text-lg font-serif font-semibold leading-tight text-basic-dark">

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -26,9 +26,9 @@ type ButtonProps = ButtonAsButton | ButtonAsLink;
 // ===============================================================
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    "bg-gold-primary text-basic-dark shadow-[0_0_20px_rgba(212,175,106,0.25)] hover:bg-gold-dark hover:shadow-[0_0_30px_rgba(212,175,106,0.35)] transition-all duration-300",
+    "bg-accent-primary text-basic-dark shadow-[0_0_20px_rgba(212,175,106,0.25)] hover:bg-accent-hover hover:shadow-[0_0_30px_rgba(212,175,106,0.35)] active:bg-accent-active transition-all duration-300",
   secondary:
-    "border-2 border-gold-primary text-gold-primary hover:bg-gold-soft/20 hover:text-gold-dark transition-all duration-300",
+    "border-2 border-accent-primary text-accent-primary hover:bg-accent-soft/20 hover:text-accent-hover active:bg-accent-soft/10 transition-all duration-300",
 };
 
 export default function Button(props: ButtonProps) {
@@ -38,7 +38,7 @@ export default function Button(props: ButtonProps) {
     return (
       <a
         className={cn(
-          "inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-sans font-medium leading-tight rounded-lg transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold-primary",
+          "inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-sans font-medium leading-tight rounded-lg transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary",
           variantClasses[variant],
           className,
         )}
@@ -54,7 +54,7 @@ export default function Button(props: ButtonProps) {
   return (
     <button
       className={cn(
-        "inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-sans font-medium leading-tight rounded-lg transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold-primary",
+        "inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-sans font-medium leading-tight rounded-lg transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary",
         variantClasses[variant],
         className,
       )}

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -28,8 +28,8 @@ export default function Heading({
 
   const colorClasses: Record<HeadingColor, string> = {
     basic: "text-basic-dark",
-    gold: "text-gold-primary",
-    soft: "text-gold-soft",
+    gold: "text-accent-primary",
+    soft: "text-accent-soft",
   };
 
   return <Tag className={cn(levelClasses[level], colorClasses[color], className)}>{children}</Tag>;

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -20,7 +20,7 @@ export default function Section({
   children,
 }: SectionProps) {
   const variantClasses: Record<SectionVariant, string> = {
-    dark: "bg-basic-dark text-gold-soft",
+    dark: "bg-basic-dark text-accent-soft",
     light: "bg-basic-light text-basic-dark",
   };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,10 +11,11 @@ module.exports = {
           dark: "#1E1B19",
           light: "#F6F1E9",
         },
-        gold: {
+        accent: {
           primary: "#D4AF6A",
-          dark: "#C69C5A",
+          hover: "#C69C5A",
           soft: "#F2E5C2",
+          active: "#B8924F",
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Изменения
- 🎨 Переименовал цветовую секцию gold в accent в Tailwind и добавил активный оттенок для токенов.
- 🔁 Обновил Button и секции/лейауты на новые accent-классы, добавил active-состояния для primary/secondary.

## Тесты
- ⚠️ `npm run lint` (прервано: запрошена интерактивная настройка ESLint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5f45c940832197519c15591cabf5)