### PR TITLE
Поддержка auto-shimmer на всех устройствах

### DIFF
--- a/styles/ui-effects.css
+++ b/styles/ui-effects.css
@@ -69,6 +69,10 @@
   z-index: 0;
 }
 
+.btn-shimmer.auto-shimmer::before {
+  animation: auto-shine 1.2s ease-out forwards;
+}
+
 .btn-shimmer:active {
   transform: scale(0.95);
   transition: transform 0.08s ease-out;
@@ -81,10 +85,4 @@
 
 .btn-shimmer:active::after {
   box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.1);
-}
-
-@media (hover: none) {
-  .btn-shimmer.auto-shimmer::before {
-    animation: auto-shine 1.2s ease-out forwards;
-  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     { pattern: /animate-/ },
     { pattern: /bg-\[/ },
     { pattern: /translate-x/ },
+    { pattern: /auto-shimmer/ },
   ],
   darkMode: "class",
   theme: {


### PR DESCRIPTION
✨ Вынесено правило `.btn-shimmer.auto-shimmer::before` из медиазапроса, чтобы авто-анимация работала и при `hover: hover`, при этом сохранён текущий hover-эффект.
🛡️ В safelist Tailwind добавлен класс `auto-shimmer`; проект пересобран, селектор присутствует в итоговом CSS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f807024908321a0544de0d270bc43)