### PR TITLE
Добавить интерактивный показ описания Hero на мобильных

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,10 +1,58 @@
+"use client";
+
+import { type TouchEvent, useEffect, useState } from "react";
+
 import Button from "../ui/Button";
 import Heading from "../ui/Heading";
 import Section from "../ui/Section";
 
+const SWIPE_THRESHOLD = 40;
+
 export default function Hero() {
+  const [touchStartX, setTouchStartX] = useState<number | null>(null);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [isDescriptionVisible, setIsDescriptionVisible] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      const matches = event.matches;
+      setIsDesktop(matches);
+      setIsDescriptionVisible(matches);
+    };
+
+    handleChange(mediaQuery);
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (isDesktop) return;
+
+    setTouchStartX(event.touches[0]?.clientX ?? null);
+  };
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    if (isDesktop || touchStartX === null) return;
+
+    const deltaX = (event.changedTouches[0]?.clientX ?? 0) - touchStartX;
+
+    if (deltaX > SWIPE_THRESHOLD) {
+      setIsDescriptionVisible(true);
+    }
+
+    setTouchStartX(null);
+  };
+
   return (
-    <Section id="hero" variant="dark">
+    <Section
+      id="hero"
+      variant="dark"
+      onTouchEnd={handleTouchEnd}
+      onTouchStart={handleTouchStart}
+    >
       <div className="flex flex-col gap-mobile-6 md:gap-10">
         <div className="flex-1 space-y-mobile-4 md:space-y-6">
           <Heading level={1} color="soft">
@@ -12,12 +60,21 @@ export default function Hero() {
             <br />
             Новый формат психотерапии
           </Heading>
-          <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-accent-soft md:max-w-2xl md:text-base md:leading-relaxed">
-            Диалектически-экзистенциальная терапия — это культура понимания человека. DETai — это технологическая экосистема,
-            включающая продукты, интерфейсы и AI-инструменты, которые воплощают культуру DET в прикладных и ежедневных формах —
-            доступных как клиентам, так и психотерапевтам.
-          </p>
-          <div className="flex flex-wrap items-center gap-mobile-4 md:gap-6">
+          {!isDesktop && !isDescriptionVisible ? (
+            <div className="flex w-full items-center justify-center">
+              <div className="flex items-center gap-2 rounded-full border border-accent-soft/30 bg-basic-dark/70 px-4 py-2 text-mobile-sm text-accent-soft shadow-lg backdrop-blur-md">
+                <span className="text-mobile-lg font-semibold text-accent-primary">→</span>
+                <span className="whitespace-nowrap font-medium">Свайп вправо, чтобы раскрыть описание</span>
+              </div>
+            </div>
+          ) : (
+            <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-accent-soft md:max-w-2xl md:text-lg md:leading-relaxed">
+              Диалектически-экзистенциальная терапия — это культура понимания человека. DETai — это технологическая экосистема,
+              включающая продукты, интерфейсы и AI-инструменты, которые воплощают культуру DET в прикладных и ежедневных формах —
+              доступных как клиентам, так и психотерапевтам.
+            </p>
+          )}
+          <div className="flex flex-wrap items-center justify-center gap-mobile-4 md:justify-start md:gap-6">
             <Button as="a" href="#fundament-det" variant="primary">
               Фундамент DET
             </Button>

--- a/components/ui/Section.tsx
+++ b/components/ui/Section.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, type TouchEventHandler } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,6 +9,8 @@ type SectionProps = {
   variant?: SectionVariant;
   className?: string;
   containerClassName?: string;
+  onTouchStart?: TouchEventHandler<HTMLDivElement>;
+  onTouchEnd?: TouchEventHandler<HTMLDivElement>;
   children: ReactNode;
 };
 
@@ -17,6 +19,8 @@ export default function Section({
   variant = "light",
   className,
   containerClassName,
+  onTouchEnd,
+  onTouchStart,
   children,
 }: SectionProps) {
   const variantClasses: Record<SectionVariant, string> = {
@@ -31,6 +35,8 @@ export default function Section({
           "mx-auto w-full max-w-mobile px-mobile-4 py-mobile-6 md:max-w-6xl md:px-10 md:py-20",
           containerClassName,
         )}
+        onTouchEnd={onTouchEnd}
+        onTouchStart={onTouchStart}
       >
         {children}
       </div>


### PR DESCRIPTION
## Описание
- ✨ Возврат крупного текста описания в Hero на десктопе
- 👉 Добавлен свайп вправо для раскрытия описания на мобильных, вместе с подсказкой
- 🎯 Центрированы кнопки в Hero для мобильной версии и расширены возможности секции для обработки тач-событий


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69301f6b90c483218d1922b95c3ea326)