### PR TITLE
Use mobile typography token in hero subheading

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
           <Heading
             level={1}
             color="soft"
-            className="text-[1.4rem] leading-[1.9rem] md:text-4xl md:leading-tight"
+            className="text-mobile-xl md:text-4xl md:leading-tight"
           >
             Новый формат психотерапии
           </Heading>


### PR DESCRIPTION
## Summary
- ✨ Перевёл мобильный подзаголовок блока Hero на типографический токен `text-mobile-xl` вместо точечных значений, сохранив медиастили.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693036b5a74c83218a4a01f249c2aebe)