### PR TITLE
Use static DETai logo on hero

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ export default function Hero() {
         <div className="absolute inset-0 h-full bg-basic-dark/50" />
 
         <div className="relative flex w-full flex-col items-start gap-mobile-3 text-left">
-          <AnimatedLogo className="h-28 w-28" />
+          <AnimatedLogo className="h-28 w-28 self-end" />
           <Heading level={1} color="soft" className="text-mobile-4xl leading-mobile-tight md:text-5xl">
             DET — Dialectical Existential Therapy.
           </Heading>
@@ -44,8 +44,7 @@ export default function Hero() {
       </div>
 
       <div className="hidden flex-col gap-6 py-16 md:flex md:gap-10 md:py-24">
-        <div className="flex items-start gap-6">
-          <AnimatedLogo className="flex-shrink-0 h-32 w-32" />
+        <div className="flex items-start justify-between gap-6">
           <div className="flex-1 space-y-6">
             <Heading level={1} color="soft">
               DET — Dialectical Existential Therapy.
@@ -66,6 +65,7 @@ export default function Hero() {
               </Button>
             </div>
           </div>
+          <AnimatedLogo className="h-32 w-32" />
         </div>
       </div>
     </Section>

--- a/components/visual/AnimatedLogo.tsx
+++ b/components/visual/AnimatedLogo.tsx
@@ -3,12 +3,12 @@
 import Lottie from "lottie-react";
 import clsx from "clsx";
 
-import animationData from "@/public/assets/animations/logo-detai.json";
+import animationData from "@/public/assets/animations/logo-detai-static.json";
 
 type AnimatedLogoProps = {
   className?: string;
 };
 
 export default function AnimatedLogo({ className }: AnimatedLogoProps) {
-  return <Lottie animationData={animationData} loop autoplay className={clsx("h-48 w-48", className)} />;
+  return <Lottie animationData={animationData} loop={false} autoplay className={clsx("h-48 w-48", className)} />;
 }


### PR DESCRIPTION
## Изменения
- ✨ Подключён статичный Lottie-логотип DETai в компонент AnimatedLogo
- 🎯 Логотип в Hero перенесён на правый край для мобильной и десктопной вёрстки

## Тесты
- ⚠️ `npm run lint` (остановлен, так как команда запросила интерактивную настройку ESLint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e49336cc8321a19a9263fda021b5)