### PR TITLE
Выравнивание текста Hero и ограничение сцены

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
       containerClassName="relative flex flex-col gap-8 md:gap-12"
       fullWidth
     >
-      <div className="relative z-20 w-full max-w-screen-md">
+      <div className="relative z-20 w-full max-w-[48rem] md:max-w-[52rem]">
         <Heading level={1} color="soft" className="text-mobile-4xl leading-mobile-tight md:text-5xl">
           DET — Dialectical Existential Therapy.
         </Heading>
@@ -21,8 +21,8 @@ export default function Hero() {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 items-start gap-8 md:grid-cols-[minmax(0,48ch)_1fr] md:items-center md:gap-12">
-        <div className="order-2 flex w-full max-w-screen-md flex-col gap-mobile-3 md:order-1 md:gap-6">
+      <div className="grid grid-cols-1 items-start gap-8 md:grid-cols-[minmax(30rem,1.05fr)_minmax(24rem,0.95fr)] md:items-start md:gap-10 lg:grid-cols-[minmax(36rem,1fr)_minmax(28rem,1fr)] lg:gap-14">
+        <div className="order-2 flex w-full max-w-[48rem] flex-col gap-mobile-3 md:order-1 md:max-w-none md:gap-6">
           <p className="text-lg leading-relaxed text-accent-soft md:text-xl">
             Диалектически-экзистенциальная терапия — это культура понимания человека. DETai — это технологическая экосистема,
             включая продукты, интерфейсы и AI-инструменты, которые воплощают культуру DET в прикладных и ежедневных формах —
@@ -38,7 +38,10 @@ export default function Hero() {
           </div>
         </div>
 
-        <HeroScene className="order-1 flex-shrink-0 min-h-[22rem] md:order-2 md:ml-8 md:min-h-[30rem] lg:ml-12" logoSize="32rem" />
+        <HeroScene
+          className="order-1 flex-shrink-0 overflow-hidden min-h-[22rem] md:order-2 md:min-h-[30rem] md:ml-12 lg:ml-16 xl:ml-20"
+          logoSize="32rem"
+        />
       </div>
     </Section>
   );


### PR DESCRIPTION
✨ Выравняли абзац и кнопки по левому краю слогана для ровного отступа.
🚧 Зафиксировали ширину текстовой колонки и старт HeroScene после неё, чтобы эффекты не заходили на текст.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc298c55c83219066f55eb97a3d7d)