### PR TITLE
🔧 Усилить разброс спавна для локальных частиц

### DIFF
--- a/components/visual/CanvasLocalParticlesLayer.tsx
+++ b/components/visual/CanvasLocalParticlesLayer.tsx
@@ -146,6 +146,12 @@ export default function CanvasLocalParticlesLayer({ className }: CanvasLocalPart
     const centerY = height / 2;
     const margin = Math.min(width, height) * 0.03;
     const spawnSpread = Math.min(width, height) * 0.18;
+    const SPAWN_SIDE_MULTIPLIER = {
+      top: 1.9,
+      left: 1.7,
+      right: 1.0,
+      bottom: 1.0,
+    };
 
 
     const radius = Math.min(width, height) * 0.16;
@@ -156,7 +162,14 @@ export default function CanvasLocalParticlesLayer({ className }: CanvasLocalPart
       ty: number;
     }> = [
       {
-
+        spawn: () => [
+          Math.random() * width,
+          -margin +
+            randomBetween(
+              -spawnSpread * SPAWN_SIDE_MULTIPLIER.top,
+              spawnSpread * SPAWN_SIDE_MULTIPLIER.top,
+            ),
+        ],
         tx: centerX,
         ty: centerY - radius,
       },
@@ -166,7 +179,14 @@ export default function CanvasLocalParticlesLayer({ className }: CanvasLocalPart
         ty: centerY + radius,
       },
       {
-
+        spawn: () => [
+          -margin +
+            randomBetween(
+              -spawnSpread * SPAWN_SIDE_MULTIPLIER.left,
+              spawnSpread * SPAWN_SIDE_MULTIPLIER.left,
+            ),
+          Math.random() * height,
+        ],
         tx: centerX - radius,
         ty: centerY,
       },


### PR DESCRIPTION
- Добавил константу SPAWN_SIDE_MULTIPLIER рядом со spawnSpread, чтобы управлять разбросом по сторонам.
- Увеличил радиус спавна сверху и слева через новые коэффициенты, оставив правую и нижнюю стороны без изменений.
✨ Более плавная картина частиц!

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb20f974883218564b8f27c34ce19)