### PR TITLE
Обновить мобильную карточку DET и выравнивание текста секции

### DIFF
--- a/components/sections/FundamentDetSection.tsx
+++ b/components/sections/FundamentDetSection.tsx
@@ -1,4 +1,5 @@
 import Button from "../ui/Button";
+import BodyText from "../ui/BodyText";
 import Heading from "../ui/Heading";
 import Section from "../ui/Section";
 
@@ -7,17 +8,17 @@ export default function FundamentDetSection() {
     <Section id="fundament-det">
       <div className="flex flex-col gap-mobile-6 md:gap-8">
         <Heading level={2}>Фундамент DET</Heading>
-        <div className="space-y-mobile-4 text-mobile-lg leading-mobile-normal text-basic-dark md:space-y-6 md:text-base md:leading-relaxed">
-          <p>
+        <div className="space-y-mobile-4 md:space-y-6">
+          <BodyText className="text-basic-dark md:text-base md:leading-relaxed">
             ✨ DET — это культурная и методологическая рамка, которая помогает видеть человека в его глубине, движении и внутренней
             диалектике. Это надшкольный способ мышления, соединяющий экзистенциальную психологию, исследовательскую позицию и
             культуру присутствия.
-          </p>
-          <p>
+          </BodyText>
+          <BodyText className="text-basic-dark md:text-base md:leading-relaxed">
             Фундамент DET опирается на четыре уровня: концепцию, метод, платформу и проектную архитектуру. Вместе они образуют
             целостную систему, где смысл и практика поддерживают друг друга. Если тебе откликается идея внутренней честности,
             развития и диалектики — здесь начинается вход в глубинную часть DET.
-          </p>
+          </BodyText>
         </div>
         <div className="flex flex-col gap-mobile-3 md:flex-row md:items-center md:gap-4">
           <Button as="a" href="/det" className="w-fit" variant="primary">

--- a/components/ui/DetDetaiMobileCard.tsx
+++ b/components/ui/DetDetaiMobileCard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
+import BodyText from "./BodyText";
 
 type DetDetaiMobileCardProps = {
   paragraphs: string[];
@@ -12,29 +13,36 @@ type DetDetaiMobileCardProps = {
 export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMobileCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const { firstSentence, remainingText } = useMemo(() => {
-    const [firstParagraph = "", ...rest] = paragraphs;
+  const { firstSentence, remainingParagraphs, remainingText } = useMemo(() => {
+    const normalizedParagraphs = paragraphs.map((paragraph) => paragraph.trim()).filter(Boolean);
+    const [firstParagraph = "", ...rest] = normalizedParagraphs;
     const firstSentenceEnd = firstParagraph.indexOf(".");
 
     const sentenceEndIndex = firstSentenceEnd >= 0 ? firstSentenceEnd + 1 : firstParagraph.length;
     const firstSentenceText = firstParagraph.slice(0, sentenceEndIndex).trim();
 
-    const remaining = [firstParagraph.slice(sentenceEndIndex).trim(), ...rest]
-      .filter(Boolean)
-      .join(" ")
-      .trim();
+    const remaining = [firstParagraph.slice(sentenceEndIndex).trim(), ...rest].filter(Boolean);
+    const combinedRemainingText = remaining.join("\n\n").trim();
 
-    return { firstSentence: firstSentenceText, remainingText: remaining };
+    return {
+      firstSentence: firstSentenceText,
+      remainingParagraphs: remaining,
+      remainingText: combinedRemainingText,
+    };
   }, [paragraphs]);
 
-  const previewText = useMemo(() => remainingText.slice(0, 220), [remainingText]);
+  const previewText = useMemo(() => remainingText.slice(0, 320), [remainingText]);
+  const previewParagraphs = useMemo(
+    () => previewText.split(/\n\n+/).map((paragraph) => paragraph.trim()).filter(Boolean),
+    [previewText],
+  );
 
   return (
     <div
       className={cn(
         "md:hidden",
-        "relative isolate left-1/2 w-screen -translate-x-1/2 overflow-hidden rounded-none border-y border-accent-primary/20 bg-basic-light px-mobile-4 py-mobile-5 shadow-[0_12px_40px_-12px_rgba(43,32,20,0.24)]",
-        "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_12%_10%,rgba(255,197,143,0.24),transparent_46%),radial-gradient(circle_at_92%_12%,rgba(204,228,255,0.24),transparent_44%)]",
+        "relative isolate left-1/2 w-screen -translate-x-1/2 overflow-hidden rounded-none border-y border-accent-primary/20 bg-gradient-to-br from-basic-dark via-basic-dark to-accent-active/40 px-mobile-4 py-mobile-5 shadow-[0_12px_40px_-12px_rgba(43,32,20,0.24)]",
+        "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_12%_10%,rgba(201,168,106,0.22),transparent_46%),radial-gradient(circle_at_92%_12%,rgba(178,146,79,0.18),transparent_44%)]",
         className,
       )}
       role="button"
@@ -49,20 +57,28 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
       aria-expanded={isExpanded}
       aria-label={isExpanded ? "Свернуть текст" : "Развернуть текст"}
     >
-      <div className="relative flex flex-col gap-mobile-3 text-basic-dark">
-        <p className="font-sans text-mobile-lg leading-mobile-normal">{firstSentence}</p>
+      <div className="relative flex flex-col gap-mobile-4 text-accent-soft">
+        <BodyText>{firstSentence}</BodyText>
 
         {isExpanded ? (
-          <p className="font-sans text-mobile-lg leading-mobile-normal text-basic-dark/90">{remainingText}</p>
-        ) : remainingText ? (
-          <p className="font-sans text-mobile-base leading-mobile-normal text-basic-dark/60">{previewText}</p>
+          <div className="flex flex-col gap-mobile-3">
+            {remainingParagraphs.map((paragraph, index) => (
+              <BodyText key={index}>{paragraph}</BodyText>
+            ))}
+          </div>
+        ) : previewParagraphs.length ? (
+          <div className="flex flex-col gap-mobile-3">
+            {previewParagraphs.map((paragraph, index) => (
+              <BodyText key={index}>{paragraph}</BodyText>
+            ))}
+          </div>
         ) : null}
       </div>
 
       {!isExpanded && remainingText ? (
         <>
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-basic-light via-basic-light/70 to-transparent" />
-          <span className="pointer-events-none absolute bottom-mobile-3 right-mobile-4 text-mobile-sm font-semibold uppercase tracking-wide text-accent-primary">
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-basic-dark via-basic-dark/70 to-transparent" />
+          <span className="pointer-events-none absolute bottom-mobile-3 right-mobile-4 text-mobile-sm font-semibold uppercase tracking-wide text-accent-soft">
             Читать дальше
           </span>
         </>


### PR DESCRIPTION
## Изменения
- ✨ Привёл DetDetaiMobileCard к единым токенам BodyText, удлинил превью и сохранил абзацы.
- 🎨 Обновил фон карточки на брендовый градиент и уменьшил зону затемнения, чтобы больше текста оставалось видимым.
- 📝 Заменил ручные абзацы в FundamentDetSection на BodyText с базовой типографикой и нужным цветом.

## Тестирование
- ⚠️ `npm run lint` (отменено из-за интерактивного запроса настройки ESLint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407fad22008321b48cd97a9f1cd673)