### PR TITLE
Выделить отдельные компоненты заголовков для hero и секций

### DIFF
--- a/components/sections/AudienceSection.tsx
+++ b/components/sections/AudienceSection.tsx
@@ -1,4 +1,4 @@
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 const audienceCards = [
@@ -28,7 +28,7 @@ export default function AudienceSection() {
   return (
     <Section>
       <div className="flex flex-col gap-mobile-4 md:gap-6">
-        <Heading level={2}>Для кого DET и DETai</Heading>
+        <HeadingLevel2>Для кого DET и DETai</HeadingLevel2>
         <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-basic-dark md:max-w-2xl md:text-base md:leading-relaxed">
           DET — это культурная рамка понимания человека и тип внутренней позиции. DETai — её технологическое продолжение. Вместе
           они создают смыслы и инструменты для тех, кто развивается сам и помогает развиваться другим: психологам,

--- a/components/sections/DetDetaiSplit.tsx
+++ b/components/sections/DetDetaiSplit.tsx
@@ -1,14 +1,14 @@
 import Button from "../ui/Button";
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 export default function DetDetaiSplit() {
   return (
     <Section containerClassName="text-center">
       <div className="flex flex-col items-center gap-mobile-4 md:gap-6">
-        <Heading level={2} color="basic">
+        <HeadingLevel2 color="basic">
           Выберите направление
-        </Heading>
+        </HeadingLevel2>
         <div className="flex w-full flex-col gap-mobile-4 md:flex-row md:items-center md:justify-center md:gap-6">
           <Button as="a" href="/det" variant="secondary" className="w-full md:w-auto">
             Перейти к DET

--- a/components/sections/DetToDetaiBridge.tsx
+++ b/components/sections/DetToDetaiBridge.tsx
@@ -1,6 +1,6 @@
 import BodyText from "../ui/BodyText";
 import DetDetaiMobileCard from "../ui/DetDetaiMobileCard";
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 export default function DetToDetaiBridge() {
@@ -13,9 +13,9 @@ export default function DetToDetaiBridge() {
   return (
     <Section variant="light">
       <div className="flex flex-col gap-mobile-6 md:gap-8">
-        <Heading level={2}>
+        <HeadingLevel2>
           DET ↔ DETai
-        </Heading>
+        </HeadingLevel2>
         <div className="hidden flex-col gap-6 md:flex md:max-w-4xl">
           {paragraphs.map((paragraph) => (
             <BodyText key={paragraph} className="text-basic-dark md:text-lg md:leading-relaxed">

--- a/components/sections/DetaiProjectsTeaser.tsx
+++ b/components/sections/DetaiProjectsTeaser.tsx
@@ -1,5 +1,5 @@
 import BodyText from "../ui/BodyText";
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 const placeholderProjects = [
@@ -25,7 +25,7 @@ export default function DetaiProjectsTeaser() {
     <Section id="detai-projects" className="border-y border-accent-primary/20 bg-basic-light">
       <div className="flex flex-col gap-mobile-6 md:gap-10">
         <div className="flex flex-col gap-mobile-2 md:gap-3">
-          <Heading level={2}>Проекты DETai</Heading>
+          <HeadingLevel2>Проекты DETai</HeadingLevel2>
           <BodyText className="max-w-3xl text-basic-dark md:text-lg md:leading-relaxed">
             Практические формы применения диалектически-экзистенциальной терапии в технологической экосистеме DETai.
           </BodyText>

--- a/components/sections/FundamentDetSection.tsx
+++ b/components/sections/FundamentDetSection.tsx
@@ -1,13 +1,13 @@
 import Button from "../ui/Button";
 import BodyText from "../ui/BodyText";
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 export default function FundamentDetSection() {
   return (
     <Section id="fundament-det">
       <div className="flex flex-col gap-mobile-6 md:gap-8">
-        <Heading level={2}>Фундамент DET</Heading>
+        <HeadingLevel2>Фундамент DET</HeadingLevel2>
         <div className="space-y-mobile-4 md:space-y-6">
           <BodyText className="text-basic-dark md:text-base md:leading-relaxed">
             ✨ DET — это культурная и методологическая рамка, которая помогает видеть человека в его глубине, движении и внутренней

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,7 +1,7 @@
 import HeroScene from "./HeroScene";
 import Button from "../ui/Button";
 import BodyText from "../ui/BodyText";
-import Heading from "../ui/Heading";
+import HeroHeadingTitle from "../ui/HeroHeadingTitle";
 import Section from "../ui/Section";
 
 export default function Hero() {
@@ -14,9 +14,9 @@ export default function Hero() {
       fullWidth
     >
       <div className="relative z-20 w-full max-w-[48rem] md:max-w-[52rem]">
-        <Heading level={1} color="soft" className="text-mobile-4xl leading-mobile-tight md:text-5xl">
+        <HeroHeadingTitle>
           DET — Dialectical Existential Therapy.
-        </Heading>
+        </HeroHeadingTitle>
         <p className="mt-4 text-lg leading-snug text-accent-soft md:text-xl lg:text-2xl">
           Новый формат психотерапии
         </p>

--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -1,13 +1,13 @@
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 export default function Mission() {
   return (
     <Section id="mission" variant="dark">
       <div className="flex flex-col gap-mobile-6 md:gap-8">
-        <Heading level={2} color="soft">
+        <HeadingLevel2 color="soft">
           Наша миссия
-        </Heading>
+        </HeadingLevel2>
         <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-accent-soft md:max-w-2xl md:text-base md:leading-relaxed">
           Создать новую терапевтическую логику, которая объединяет глубину экзистенциальной психологии и возможности современного
           интеллекта — человеческого и искусственного. DET и DETai — это путь к осмысленным инструментам, которые помогают людям

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -1,4 +1,4 @@
-import Heading from "../ui/Heading";
+import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
 const projects = [
@@ -38,7 +38,7 @@ export default function Projects() {
   return (
     <Section id="projects">
       <div className="mb-mobile-6 flex flex-col gap-mobile-3 md:mb-12 md:gap-4">
-        <Heading level={2}>Проекты DETai</Heading>
+        <HeadingLevel2>Проекты DETai</HeadingLevel2>
         <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-basic-dark md:max-w-2xl md:text-base md:leading-relaxed">
           Практические инструменты, создаваемые на основе метода DET и работающие в технологической экосистеме DETai.
         </p>

--- a/components/ui/HeadingLevel2.tsx
+++ b/components/ui/HeadingLevel2.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from "react";
+
+import Heading from "./Heading";
+
+type SectionHeadingColor = "basic" | "gold" | "soft";
+
+type HeadingLevel2Props = {
+  children: ReactNode;
+  className?: string;
+  color?: SectionHeadingColor;
+};
+
+export default function HeadingLevel2({ children, className, color = "basic" }: HeadingLevel2Props) {
+  return (
+    <Heading level={2} color={color} className={className}>
+      {children}
+    </Heading>
+  );
+}

--- a/components/ui/HeroHeadingTitle.tsx
+++ b/components/ui/HeroHeadingTitle.tsx
@@ -1,0 +1,17 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import Heading from "./Heading";
+
+type HeroHeadingTitleProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function HeroHeadingTitle({ children, className }: HeroHeadingTitleProps) {
+  return (
+    <Heading level={1} color="soft" className={cn("text-mobile-4xl leading-mobile-tight md:text-5xl", className)}>
+      {children}
+    </Heading>
+  );
+}


### PR DESCRIPTION
## Изменения
- ✨ Добавлен компонент HeroHeadingTitle на базе текущего H1 для hero-блока.
- 🧭 Создан HeadingLevel2 и применён ко всем секционным заголовкам домашней страницы.

## Тесты
- ⚠️ `npm run lint` (прервано из-за интерактивного запроса Next.js о конфигурации ESLint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bbce02648321ace64a16d0376907)