### PR TITLE
Уточняет ширину мобильной карточки DetDetai

### DIFF
--- a/components/ui/DetDetaiMobileCard.tsx
+++ b/components/ui/DetDetaiMobileCard.tsx
@@ -41,7 +41,7 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
     <div
       className={cn(
         "md:hidden",
-        "relative isolate left-1/2 w-screen -translate-x-1/2 overflow-hidden rounded-none border-y border-accent-primary/20",
+        "relative isolate overflow-hidden w-full -mx-mobile-4 rounded-none border-y border-accent-primary/20",
         "bg-gradient-to-br from-basic-light via-white to-accent-soft/80 px-mobile-4 py-mobile-5 shadow-[0_18px_48px_-18px_rgba(185,146,79,0.35)]",
         "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_16%_22%,rgba(201,168,106,0.22),transparent_44%),radial-gradient(circle_at_92%_18%,rgba(242,229,194,0.5),transparent_48%)]",
         className,


### PR DESCRIPTION
## Описание
- ✨ Перевёл мобильную карточку на контейнерный подход: `w-full` с отрицательными отступами для компенсации паддингов секции
- 🛡️ Сохранил скрытие блока на `md` и стабильную ширину при развороте текста

## Тесты
- ⏭️ Не запускались (не требовалось)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694323333bc483219352f0e496050801)