### PR TITLE
Добавить светлый вариант BodyText и обновить секции главной

### DIFF
--- a/components/sections/DetToDetaiBridge.tsx
+++ b/components/sections/DetToDetaiBridge.tsx
@@ -18,7 +18,7 @@ export default function DetToDetaiBridge() {
         </HeadingLevel2>
         <div className="hidden flex-col gap-6 md:flex md:max-w-4xl">
           {paragraphs.map((paragraph) => (
-            <BodyText key={paragraph} className="text-basic-dark md:text-lg md:leading-relaxed">
+            <BodyText key={paragraph} variant="sectionDefaultOnLight">
               {paragraph}
             </BodyText>
           ))}

--- a/components/sections/DetaiProjectsTeaser.tsx
+++ b/components/sections/DetaiProjectsTeaser.tsx
@@ -48,7 +48,7 @@ export default function DetaiProjectsTeaser() {
       <div className="flex flex-col gap-mobile-6 md:gap-10">
         <div className="flex flex-col gap-mobile-2 md:gap-3">
           <HeadingLevel2 color="soft">Проекты DETai</HeadingLevel2>
-          <BodyText className="max-w-3xl text-accent-soft/90 md:text-lg md:leading-relaxed">
+          <BodyText className="max-w-3xl" variant="sectionDefaultDark">
             Практические формы применения диалектически-экзистенциальной терапии в технологической экосистеме DETai.
           </BodyText>
         </div>

--- a/components/sections/FundamentDetSection.tsx
+++ b/components/sections/FundamentDetSection.tsx
@@ -9,12 +9,12 @@ export default function FundamentDetSection() {
       <div className="flex flex-col gap-mobile-6 md:gap-8">
         <HeadingLevel2>Фундамент DET</HeadingLevel2>
         <div className="space-y-mobile-4 md:space-y-6">
-          <BodyText className="text-basic-dark md:text-base md:leading-relaxed">
+          <BodyText variant="sectionDefaultOnLight">
             ✨ DET — это культурная и методологическая рамка, которая помогает видеть человека в его глубине, движении и внутренней
             диалектике. Это надшкольный способ мышления, соединяющий экзистенциальную психологию, исследовательскую позицию и
             культуру присутствия.
           </BodyText>
-          <BodyText className="text-basic-dark md:text-base md:leading-relaxed">
+          <BodyText variant="sectionDefaultOnLight">
             Фундамент DET опирается на четыре уровня: концепцию, метод, платформу и проектную архитектуру. Вместе они образуют
             целостную систему, где смысл и практика поддерживают друг друга. Если тебе откликается идея внутренней честности,
             развития и диалектики — здесь начинается вход в глубинную часть DET.

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -33,7 +33,7 @@ export default function Hero() {
             так и психотерапевтам.
           </BodyText>
 
-          <BodyText className="mt-4" variant="sectionDefault">
+          <BodyText className="mt-4" variant="sectionDefaultDark">
             Вместе DET и DETai формируют новый формат психотерапии — где диалектика, гуманизм,
             и современные технологии соединяются в единую систему терапевтической практики.
           </BodyText>

--- a/components/ui/BodyText.tsx
+++ b/components/ui/BodyText.tsx
@@ -3,7 +3,8 @@ import { type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type BodyTextVariant =
-  | "sectionDefault" // обычный текст в секциях
+  | "sectionDefaultDark" // обычный текст в тёмных секциях
+  | "sectionDefaultOnLight" // обычный текст в светлых секциях
   | "sectionBrand" // акцентный текст в секциях
   | "projectCard" // карточки проектов (витрина)
   | "infoCard"; // карточки описаний / "для кого"
@@ -15,14 +16,15 @@ type BodyTextProps = {
 };
 
 const variantClasses: Record<BodyTextVariant, string> = {
-  sectionDefault: "text-mobile-lg leading-mobile-normal text-accent-soft md:text-xl md:leading-relaxed",
+  sectionDefaultDark: "text-mobile-lg leading-mobile-normal text-accent-soft md:text-xl md:leading-relaxed",
+  sectionDefaultOnLight: "text-mobile-lg leading-mobile-normal text-basic-dark md:text-xl md:leading-relaxed",
   sectionBrand: "text-mobile-lg leading-mobile-normal text-accent-primary md:text-xl md:leading-relaxed",
   projectCard: "text-mobile-base leading-mobile-tight text-basic-dark md:text-base",
   infoCard: "text-mobile-base leading-mobile-normal text-basic-dark md:text-base md:leading-relaxed",
 };
 
 export default function BodyText({
-  variant = "sectionDefault",
+  variant = "sectionDefaultDark",
   className,
   children,
 }: BodyTextProps) {

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -58,7 +58,8 @@ shimmer — это фирменная фича primary.
 
 * Базовый абзацный текстовый компонент с шрифтом Open Sans.
 * Варианты:
-  * `sectionDefault` — базовый текст для секций (по умолчанию).
+  * `sectionDefaultDark` — базовый текст для секций на тёмном фоне (по умолчанию).
+  * `sectionDefaultOnLight` — базовый текст для секций на светлом фоне.
   * `sectionBrand` — акцентный текст в секциях.
   * `projectCard` — компактный текст для карточек проектов (витрина): `text-mobile-base` + `leading-mobile-tight`, на десктопе `md:text-base`.
   * `infoCard` — текст для описательных карточек / блоков "для кого": `text-mobile-base` + `leading-mobile-normal`, на десктопе `md:text-base md:leading-relaxed`.


### PR DESCRIPTION
## Summary
- ✨ Добавлен вариант `sectionDefaultOnLight` для BodyText и переименован тёмный вариант
- 🧹 Обновлены секции главной страницы, использующие секционный текст без ручных классов
- 📚 Обновлено описание BodyText в components/ui/README.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432e8276e083218a900380351d1ea5)