### PR TITLE
Adjust canvas sizing to viewport client metrics

### DIFF
--- a/components/visual/CanvasGlobalParticlesLayer.tsx
+++ b/components/visual/CanvasGlobalParticlesLayer.tsx
@@ -264,17 +264,17 @@ export default function CanvasGlobalParticlesLayer({ className, anchorRef }: Can
 
     const performResize = () => {
       const dpr = dprRef.current;
-      const canvasRect = canvas.getBoundingClientRect();
-      const viewportWidth = document.documentElement?.clientWidth ?? 0;
-      const viewportHeight = document.documentElement?.clientHeight ?? 0;
-
-      const width = Math.max(Math.floor(canvasRect.width || viewportWidth), 0);
-      const height = Math.max(Math.floor(canvasRect.height || viewportHeight), 0);
+      const html = document.documentElement;
+      const width = Math.max(html?.clientWidth ?? 0, 0);
+      const height = Math.max(html?.clientHeight ?? 0, 0);
 
       const rect = anchorRef?.current?.getBoundingClientRect();
       const centerX = rect ? rect.left + rect.width / 2 : width / 2;
       const centerY = rect ? rect.top + rect.height / 2 : height / 2;
       const anchorSize = Math.min(rect?.width ?? width, rect?.height ?? height);
+
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
 
       canvas.width = Math.round(width * dpr);
       canvas.height = Math.round(height * dpr);
@@ -428,7 +428,7 @@ export default function CanvasGlobalParticlesLayer({ className, anchorRef }: Can
   return (
     <canvas
       ref={canvasRef}
-      className={cn("fixed inset-0 w-full h-full pointer-events-none z-20", className)}
+      className={cn("fixed inset-0 pointer-events-none z-20 w-[100dvw] h-[100dvh] overflow-clip", className)}
       aria-hidden
     />
   );

--- a/components/visual/CanvasLocalParticlesLayer.tsx
+++ b/components/visual/CanvasLocalParticlesLayer.tsx
@@ -417,10 +417,10 @@ export default function CanvasLocalParticlesLayer({ className }: CanvasLocalPart
     const performResize = () => {
       const dpr = dprRef.current;
       const parent = canvas.parentElement;
-      const rect = parent?.getBoundingClientRect();
+      const html = document.documentElement;
 
-      const width = rect?.width ?? 0;
-      const height = rect?.height ?? 0;
+      const width = Math.max(parent?.clientWidth ?? html.clientWidth ?? 0, 0);
+      const height = Math.max(parent?.clientHeight ?? html.clientHeight ?? 0, 0);
 
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;


### PR DESCRIPTION
## Резюме
- 🌌 Перешёл на вычисление размеров канвасов через `clientWidth`/`clientHeight` и явные inline-установки, чтобы исключить дергание из-за `w-full/100vw`.
- 🛡️ Глобальный слой частиц получает размеры в dvw/dvh и обрезку, центрируется по вьюпорту/якорю без дополнительной CSS-ширины.
- 🔧 Локальный слой использует `clientWidth`/`clientHeight` контейнера с защитой от нулевых размеров.

## Тесты
- ⚠️ `npm run lint` (остановил, Next.js запросил интерактивную инициализацию ESLint-конфига)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432ea7d6b08321a38edff90206c64a)