### PR TITLE
Исправить перенос меню Header на мобильных устройствах

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,7 +3,7 @@ export default function Header() {
     <header className="w-full border-b border-accent-primary/30 bg-basic-light text-basic-dark">
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
         <div className="text-lg font-serif font-semibold tracking-tight">DETai</div>
-        <nav className="flex items-center gap-4 text-sm font-sans font-medium">
+        <nav className="flex flex-wrap items-center max-w-full gap-3 text-xs font-sans font-medium sm:gap-4 sm:text-sm">
           <a className="hover:text-accent-primary" href="#hero">
             Главная
           </a>


### PR DESCRIPTION
✨ Исправление мобильного меню в Header

## Summary
- добавлен перенос строк и ограничение ширины для контейнера ссылок
- настроены мобильные отступы и размер шрифта, чтобы убрать горизонтальный скролл на маленьких экранах

## Testing
- Не запускались (не требовалось)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694339dc97bc8321a183dd79eef6c70c)