### PR TITLE
Adjust mission layout padding

### DIFF
--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -36,7 +36,7 @@ export default function Mission() {
         </Heading>
 
         <div
-          className="group relative w-full max-w-[960px] overflow-hidden rounded-[18px] bg-basic-dark/80 px-mobile-3 py-mobile-3 md:px-0 md:py-12"
+          className="group relative w-full max-w-[960px] overflow-hidden rounded-[18px] bg-basic-dark/80 px-mobile-3 py-mobile-2 md:px-0 md:py-8"
           role={shouldToggleOnClick ? "button" : undefined}
           aria-pressed={shouldToggleOnClick ? isRevealed : undefined}
           onClick={handleToggle}
@@ -61,12 +61,12 @@ export default function Mission() {
 
           <div
             className={cn(
-              "relative z-10 flex items-start justify-start px-mobile-3 py-mobile-4 text-left opacity-0 transition-opacity duration-500 ease-out md:px-10 md:py-12 md:text-left",
+              "relative z-10 flex items-start justify-start px-0 py-mobile-3 text-left opacity-0 transition-opacity duration-500 ease-out md:px-10 md:py-10 md:text-left",
               "group-active:opacity-100 group-hover:opacity-100",
               isRevealed && shouldToggleOnClick && "opacity-100"
             )}
           >
-            <div className="flex w-full flex-col gap-mobile-3 md:mx-auto md:max-w-[52rem] md:gap-4">
+            <div className="flex w-full flex-col gap-mobile-3 md:max-w-[52rem] md:gap-4">
               <BodyText className="md:text-xl md:leading-relaxed">
                 Создать новую терапевтическую логику, которая объединяет глубину экзистенциальной психологии и возможности современного
                 интеллекта — человеческого и искусственного. DET и DETai — это путь к осмысленным инструментам, которые помогают людям


### PR DESCRIPTION
## Summary
- reduce outer mission card padding and lighten vertical spacing for mobile/desktop
- align inner text layer with card padding and keep desktop inset
- keep text column left-aligned on desktop by removing auto-centering

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945641a7c8883219395a9acac453ef5)