### PR TITLE
Обновление ссылок навигации в хедере

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,10 +4,15 @@ export default function Header() {
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
         <div className="text-lg font-serif font-semibold tracking-tight">DETai</div>
         <nav className="flex flex-wrap items-center max-w-full gap-3 text-xs font-sans font-medium sm:gap-4 sm:text-sm">
-          <a className="hover:text-accent-primary" href="#hero">
+          <a className="hover:text-accent-primary" href="/">
             Главная
           </a>
-          <a className="hover:text-accent-primary" href="#projects">
+          <a
+            className="hover:text-accent-primary"
+            href="https://data.ai/"
+            rel="noreferrer"
+            target="_blank"
+          >
             Проекты
           </a>
           <a className="hover:text-accent-primary" href="#fundament-det">


### PR DESCRIPTION
## Summary
- «Главная» теперь ведёт на корневую страницу сайта
- «Проекты» открывает страницу data.ai в новой вкладке

## Testing
- npm run lint (warnings: неподдерживаемая версия TypeScript и существующие react-hooks предупреждения в визуальных компонентах)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69456417a1e08321a07c151b3ea22826)