### PR TITLE
Обновить стили и текст секции миссии

### DIFF
--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -69,7 +69,7 @@ export default function Mission() {
                   className="logo logo--accent-soft h-[9rem] w-[9rem] object-contain md:h-[12rem] md:w-[12rem]"
                   priority={false}
                 />
-                <p className="text-sm uppercase tracking-[0.18em] text-accent-soft/70">click me</p>
+                <p className="text-center text-sm uppercase tracking-[0.18em] text-accent-soft/70">click me</p>
               </div>
 
               <div
@@ -92,15 +92,15 @@ export default function Mission() {
               </div>
             </div>
 
-            <div className="flex w-full flex-col gap-4 rounded-xl border border-basic-light/10 bg-basic-dark/70 p-5 md:max-w-[18rem]">
-              <BodyText className="text-base text-accent-soft" variant="sectionDefaultDark">
-                Здесь будет текст.
+            <div className="flex w-full flex-col gap-4 md:max-w-[18rem]">
+              <BodyText className="whitespace-pre-line" variant="sectionDefaultDark">
+                {"Миссия отвечает на вопрос «зачем».\nКоманда — «с кем», а видение — «куда»."}
               </BodyText>
 
               <div className="flex flex-col gap-3">
-                <Button className="w-full">Кнопка 1</Button>
+                <Button className="w-full">Присоединиться к команде</Button>
                 <Button className="w-full" variant="secondary">
-                  Кнопка 2
+                  Наше видение
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Резюме
- ✨ Обновил текст секции миссии на фирменное сообщение с переносом строки и стандартным размером.
- 🎯 Привёл обе кнопки к фирменным стилям и задал новые подписи.
- 🎨 Убрал визуальный блок вокруг кнопок и выровнял подпись CLICK ME под логотипом.

## Тесты
- ✅ npm run lint (есть предупреждения от eslint по существующему коду)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694571314ce483218696fa58a53d62d1)