### PR TITLE
Вернуть левое выравнивание логотипа миссии на десктопе

### DIFF
--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -57,6 +57,7 @@ export default function Mission() {
                 className={cn(
                   "absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 bg-basic-dark px-6 text-center transition-opacity duration-500 ease-out",
                   "group-hover/mission:pointer-events-none group-hover/mission:opacity-0 group-active/mission:pointer-events-none group-active/mission:opacity-0",
+                  "md:items-start md:text-left",
                   isRevealed && shouldToggleOnClick && "pointer-events-none opacity-0"
                 )}
               >


### PR DESCRIPTION
## Summary
- ✨ Вернул левое выравнивание логотипа в секции «Миссия» на десктопах, сохранив центрирование на мобильных.

## Testing
- ✅ npm run lint (есть предупреждение о версии TypeScript и зависимостях useEffect)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ba4f26f88321971f6e083545aacc)