### PR TITLE
Adjust Mission heading sizing

### DIFF
--- a/components/sections/Mission.tsx
+++ b/components/sections/Mission.tsx
@@ -31,7 +31,7 @@ export default function Mission() {
         <Heading
           level={2}
           color="soft"
-          className="text-center text-mobile-4xl font-serif font-semibold leading-mobile-tight tracking-tight md:text-left md:text-5xl"
+          className="text-center md:text-left"
         >
           Наша миссия
         </Heading>


### PR DESCRIPTION
## 📝 Кратко
- Вернул заголовок блока Mission к базовым стилям уровня H2, убрав кастомные размеры.
- Сохранил выравнивание по центру на мобилках и слева на десктопах.

## ✅ Тестирование
- Не запускалось (изменения только стилей).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946956ec35c83219fdc3d8edd4e557c)