### PR TITLE
feat: базовая карточка AudienceSection

### DIFF
--- a/components/sections/AudienceSection.tsx
+++ b/components/sections/AudienceSection.tsx
@@ -1,3 +1,5 @@
+import BodyText from "../ui/BodyText";
+import DefaultCard from "../ui/DefaultCard";
 import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
@@ -29,24 +31,26 @@ export default function AudienceSection() {
     <Section>
       <div className="flex flex-col gap-mobile-4 md:gap-6">
         <HeadingLevel2>Для кого DET и DETai</HeadingLevel2>
-        <p className="max-w-mobile text-mobile-lg leading-mobile-normal text-basic-dark md:max-w-2xl md:text-base md:leading-relaxed">
+        <BodyText
+          variant="sectionDefaultOnLight"
+          className="max-w-mobile text-mobile-lg leading-mobile-normal md:max-w-2xl md:text-base md:leading-relaxed"
+        >
           DET — это культурная рамка понимания человека и тип внутренней позиции. DETai — её технологическое продолжение. Вместе
           они создают смыслы и инструменты для тех, кто развивается сам и помогает развиваться другим: психологам,
           исследователям, создателям сервисов и людям, которые чувствуют себя частью семьи с общим внутренним принципом.
-        </p>
+        </BodyText>
       </div>
 
       <div className="mt-mobile-6 grid grid-cols-1 gap-mobile-4 md:mt-12 md:grid-cols-2 md:gap-8">
         {audienceCards.map((card) => (
-          <div
-            key={card.title}
-            className="flex h-full flex-col gap-mobile-3 rounded-xl border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-6"
-          >
-            <h3 className="text-mobile-xl font-serif font-semibold leading-mobile-tight text-basic-dark md:text-2xl md:leading-snug">
-              {card.title}
-            </h3>
-            <p className="text-mobile-lg leading-mobile-normal text-basic-dark md:text-base md:leading-relaxed">{card.description}</p>
-          </div>
+          <DefaultCard key={card.title} title={card.title}>
+            <BodyText
+              variant="infoCard"
+              className="text-mobile-lg leading-mobile-normal text-basic-dark md:text-base md:leading-relaxed"
+            >
+              {card.description}
+            </BodyText>
+          </DefaultCard>
         ))}
       </div>
     </Section>

--- a/components/ui/DefaultCard.tsx
+++ b/components/ui/DefaultCard.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DefaultCardProps = {
+  title: string;
+  children: ReactNode;
+  className?: string;
+  titleAs?: "h3" | "h4";
+};
+
+const containerClasses =
+  "flex h-full flex-col gap-mobile-3 rounded-xl border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-6";
+
+const titleClasses =
+  "text-mobile-xl font-serif font-semibold leading-mobile-tight text-basic-dark md:text-2xl md:leading-snug";
+
+export default function DefaultCard({
+  title,
+  children,
+  className,
+  titleAs = "h3",
+}: DefaultCardProps) {
+  const TitleTag = titleAs;
+
+  return (
+    <div className={cn(containerClasses, className)}>
+      <TitleTag className={titleClasses}>{title}</TitleTag>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -64,3 +64,9 @@ shimmer — это фирменная фича primary.
   * `projectCard` — компактный текст для карточек проектов (витрина): `text-mobile-base` + `leading-mobile-tight`, на десктопе `md:text-base`.
   * `infoCard` — текст для описательных карточек / блоков "для кого": `text-mobile-base` + `leading-mobile-normal`, на десктопе `md:text-base md:leading-relaxed`.
 * Используй в секциях вместо локальных `<p>`, а в карточках — нужный карточный вариант, чтобы сохранять единый стиль body-текста.
+
+## DefaultCard.tsx
+
+* Базовая карточка с рамкой, мягким фоном и hover-подъёмом.
+* Принимает `title`, `children`, опционально `className` и `titleAs` (`h3` | `h4`).
+* Сохраняет вертикальный ритм: gap мобильный/desktop, отступы `p-mobile-4` → `md:p-6`, рамку `border-accent-primary/30` и тень `shadow-sm` → `hover:shadow-lg` с лёгким сдвигом вверх.


### PR DESCRIPTION
## Summary
- ✨ Добавил переиспользуемый `DefaultCard` со всеми текущими стилями карточек аудитории
- 🔄 Заменил разметку AudienceSection на новый компонент и BodyText для всех описаний
- 📝 Обновил README в ui-библиотеке с описанием карточки

## Testing
- ✅ npm run lint (warning от существующих Canvas-хуков)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694696b957d88321a90aefd32b4b5237)