### PR TITLE
Унификация типографики в AudienceSection

### DIFF
--- a/components/sections/AudienceSection.tsx
+++ b/components/sections/AudienceSection.tsx
@@ -1,6 +1,6 @@
 import BodyText from "../ui/BodyText";
 import DefaultCard from "../ui/DefaultCard";
-import HeadingLevel2 from "../ui/HeadingLevel2";
+import Heading from "../ui/Heading";
 import Section from "../ui/Section";
 
 const audienceCards = [
@@ -30,11 +30,8 @@ export default function AudienceSection() {
   return (
     <Section>
       <div className="flex flex-col gap-mobile-4 md:gap-6">
-        <HeadingLevel2>Для кого DET и DETai</HeadingLevel2>
-        <BodyText
-          variant="sectionDefaultOnLight"
-          className="max-w-mobile text-mobile-lg leading-mobile-normal md:max-w-2xl md:text-base md:leading-relaxed"
-        >
+        <Heading level={2}>Для кого DET и DETai</Heading>
+        <BodyText variant="sectionDefaultOnLight" className="max-w-mobile md:max-w-2xl">
           DET — это культурная рамка понимания человека и тип внутренней позиции. DETai — её технологическое продолжение. Вместе
           они создают смыслы и инструменты для тех, кто развивается сам и помогает развиваться другим: психологам,
           исследователям, создателям сервисов и людям, которые чувствуют себя частью семьи с общим внутренним принципом.
@@ -44,10 +41,7 @@ export default function AudienceSection() {
       <div className="mt-mobile-6 grid grid-cols-1 gap-mobile-4 md:mt-12 md:grid-cols-2 md:gap-8">
         {audienceCards.map((card) => (
           <DefaultCard key={card.title} title={card.title}>
-            <BodyText
-              variant="infoCard"
-              className="text-mobile-lg leading-mobile-normal text-basic-dark md:text-base md:leading-relaxed"
-            >
+            <BodyText variant="infoCard">
               {card.description}
             </BodyText>
           </DefaultCard>

--- a/components/ui/DefaultCard.tsx
+++ b/components/ui/DefaultCard.tsx
@@ -2,30 +2,30 @@ import { type ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
+import Heading from "./Heading";
+
 type DefaultCardProps = {
   title: string;
   children: ReactNode;
   className?: string;
-  titleAs?: "h3" | "h4";
 };
 
 const containerClasses =
   "flex h-full flex-col gap-mobile-3 rounded-xl border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-6";
 
 const titleClasses =
-  "text-mobile-xl font-serif font-semibold leading-mobile-tight text-basic-dark md:text-2xl md:leading-snug";
+  "text-mobile-xl md:text-3xl font-serif font-semibold leading-mobile-normal text-basic-dark md:leading-snug";
 
 export default function DefaultCard({
   title,
   children,
   className,
-  titleAs = "h3",
 }: DefaultCardProps) {
-  const TitleTag = titleAs;
-
   return (
     <div className={cn(containerClasses, className)}>
-      <TitleTag className={titleClasses}>{title}</TitleTag>
+      <Heading level={3} className={titleClasses}>
+        {title}
+      </Heading>
       {children}
     </div>
   );


### PR DESCRIPTION
## ✅ Что сделано
- Перевёл заголовок секции и карточек AudienceSection на компонент Heading с нужными уровнями и убрал ручные размеры BodyText.
- Привёл DefaultCard к использованию стандартного Heading третьего уровня с типовыми классами.

## 🧪 Тесты
- `npm run lint` (есть существующие предупреждения от react-hooks/exhaustive-deps)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694698f45be48321b69bea5e31a90cd6)