### PR TITLE
Add Lora font to global layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,27 @@
 import "../styles/globals.css";
 import type { ReactNode } from "react";
+import { Lora } from "next/font/google";
 
 import ShimmerAutoTrigger from "@/components/layout/ShimmerAutoTrigger";
 
+const lora = Lora({
+  subsets: ["latin", "cyrillic"],
+  weight: ["400", "500", "600"],
+  variable: "--font-lora",
+  display: "swap",
+});
+
 export const metadata = {
   title: "DETai Site",
-  description: "Dialectical Existential Therapy and DETai ecosystem"
+  description: "Dialectical Existential Therapy and DETai ecosystem",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
-      <body className="overflow-x-hidden bg-basic-light text-basic-dark antialiased">
+      <body
+        className={`${lora.variable} overflow-x-hidden bg-basic-light text-basic-dark antialiased font-serif`}
+      >
         <ShimmerAutoTrigger />
         {children}
       </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,7 +27,7 @@ module.exports = {
         },
       },
       fontFamily: {
-        serif: ["Lora", "serif"],
+        serif: ["var(--font-lora)", "serif"],
         sans: ["Open Sans", "sans-serif"],
         accent: ["Great Vibes", "cursive"],
       },


### PR DESCRIPTION
## ✨ Что изменилось
- Подключил шрифт Lora через next/font с весами 400/500/600 и применил его в глобальном layout.
- Пробросил переменную `--font-lora` и настроил `font-serif` в Tailwind на использование подключённого шрифта, чтобы `font-medium` и `font-semibold` отображались реальными весами.

## ✅ Тесты
- `npm run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469e2c9f948321b4e6a3b4545d6304)