### PR TITLE
Add Open Sans via next/font and wire to Tailwind

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,15 @@
 import "../styles/globals.css";
 import type { ReactNode } from "react";
-import { Lora } from "next/font/google";
+import { Lora, Open_Sans } from "next/font/google";
 
 import ShimmerAutoTrigger from "@/components/layout/ShimmerAutoTrigger";
+
+const openSans = Open_Sans({
+  subsets: ["latin", "cyrillic"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-open-sans",
+  display: "swap",
+});
 
 const lora = Lora({
   subsets: ["latin", "cyrillic"],
@@ -20,7 +27,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ru">
       <body
-        className={`${lora.variable} overflow-x-hidden bg-basic-light text-basic-dark antialiased font-serif`}
+        className={`${openSans.variable} ${lora.variable} overflow-x-hidden font-sans text-basic-dark bg-basic-light antialiased`}
       >
         <ShimmerAutoTrigger />
         {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,7 +28,7 @@ module.exports = {
       },
       fontFamily: {
         serif: ["var(--font-lora)", "serif"],
-        sans: ["Open Sans", "sans-serif"],
+        sans: ["var(--font-open-sans)", "system-ui", "sans-serif"],
         accent: ["Great Vibes", "cursive"],
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- add Open Sans through `next/font/google` with variable exposure and apply it as the default body font
- align Tailwind font families to use the new Open Sans and existing Lora CSS variables

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a383b3f48321b88513770c9e488e)