### PR TITLE
Adjust mobile hero heading typography

### DIFF
--- a/components/ui/HeroHeadingTitle.tsx
+++ b/components/ui/HeroHeadingTitle.tsx
@@ -10,7 +10,7 @@ type HeroHeadingTitleProps = {
 
 export default function HeroHeadingTitle({ children, className }: HeroHeadingTitleProps) {
   return (
-    <Heading level={1} color="soft" className={cn("text-mobile-hero md:text-5xl", className)}>
+    <Heading level={1} color="soft" className={cn("text-mobile-h1 md:text-5xl", className)}>
       {children}
     </Heading>
   );


### PR DESCRIPTION
## Изменения
- ✨ Ослабил мобильный размер заголовка Hero до токена `text-mobile-h1`, сохранив `md:text-5xl`.
- 🛠️ Секция Hero продолжает выводить прежний текст без добавления новых классов.

## Тесты
- ⏭️ Не запускались (не требовались).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bcb57efc83218792c4f02fd2edbf)