### PR TITLE
Refine project card headings

### DIFF
--- a/components/sections/DetaiProjectCard.tsx
+++ b/components/sections/DetaiProjectCard.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useEffect, useRef, type MouseEvent } from "react";
 
 import BodyText from "../ui/BodyText";
+import Heading from "../ui/Heading";
 
 type DetaiProjectCardProps = {
   title: string;
@@ -120,7 +121,9 @@ export default function DetaiProjectCard({ title, description, avatarSrc, echelo
               <div className="h-18 w-18 shrink-0 rounded-lg border border-accent-primary/10 bg-basic-dark/15" aria-hidden />
             </div>
 
-            <h3 className="font-serif text-mobile-h3 leading-tight font-semibold text-accent-soft md:text-xl md:leading-tight">{title}</h3>
+            <Heading color="soft" level={3} className="leading-tight md:text-xl md:leading-tight">
+              {title}
+            </Heading>
 
             <BodyText variant="projectCard" className="text-accent-soft/80">
               {description}

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -1,3 +1,4 @@
+import Heading from "../ui/Heading";
 import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
@@ -50,10 +51,13 @@ export default function Projects() {
             className="group flex h-full flex-col gap-mobile-3 rounded-lg border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-5"
             href={project.href}
           >
-            <div className="flex items-center gap-mobile-3 text-mobile-h3 font-serif font-semibold text-basic-dark md:gap-3 md:text-lg md:leading-tight">
+            <Heading
+              level={3}
+              className="flex items-center gap-mobile-3 leading-tight md:gap-3 md:text-lg md:leading-tight"
+            >
               <span aria-hidden>{project.icon}</span>
               <span>{project.name}</span>
-            </div>
+            </Heading>
             <p className="mt-mobile-2 text-mobile-body text-basic-dark md:mt-1 md:text-base md:leading-relaxed">
               {project.description}
             </p>


### PR DESCRIPTION
✨ Итог
- заменил заголовки карточек Projects на компонент Heading с улучшенными токенами контраста
- привёл карточки DetaiProjectsTeaser к использованию Heading для заголовков

🧪 Тесты
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bef5f3288321af4520e0e2a58167)