### PR TITLE
Adjust mobile hero heading size

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,7 +47,7 @@ module.exports = {
       },
       fontSize: {
         // Mobile semantic typography
-        "mobile-hero": ["3rem", { lineHeight: "3.5rem" }],
+        "mobile-hero": ["2.5rem", { lineHeight: "3rem" }],
         "mobile-h1": ["2rem", { lineHeight: "2.4rem" }],
         "mobile-h2": ["2.75rem", { lineHeight: "3.5rem" }],
         "mobile-h3": ["1.375rem", { lineHeight: "1.9rem" }],


### PR DESCRIPTION
## Summary
- ✨ Уменьшил размер шрифта `text-mobile-hero` до 2.5rem с линией 3rem, чтобы он оставался больше заголовка первого типа без излишней громоздкости.

## Testing
- ❓ Не запускал тесты (не требовалось)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bf2860788321afc392700ea8768b)