### PR TITLE
Adjust mobile hero and section typography

### DIFF
--- a/components/sections/DetaiProjectCard.tsx
+++ b/components/sections/DetaiProjectCard.tsx
@@ -120,7 +120,11 @@ export default function DetaiProjectCard({ title, description, avatarSrc, echelo
               <div className="h-18 w-18 shrink-0 rounded-lg border border-accent-primary/10 bg-basic-dark/15" aria-hidden />
             </div>
 
-            <h3 className="font-serif text-mobile-h3 leading-tight font-semibold text-accent-soft md:text-xl md:leading-tight">{title}</h3>
+            <h3
+              className="font-serif text-[1.25rem] leading-[1.65rem] font-semibold text-accent-soft md:text-xl md:leading-tight"
+            >
+              {title}
+            </h3>
 
             <BodyText variant="projectCard" className="text-accent-soft/80">
               {description}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,9 +47,9 @@ module.exports = {
       },
       fontSize: {
         // Mobile semantic typography
-        "mobile-hero": ["2.5rem", { lineHeight: "3rem" }],
+        "mobile-hero": ["2.25rem", { lineHeight: "2.8rem" }],
         "mobile-h1": ["2rem", { lineHeight: "2.4rem" }],
-        "mobile-h2": ["2.75rem", { lineHeight: "3.5rem" }],
+        "mobile-h2": ["1.5rem", { lineHeight: "2rem" }],
         "mobile-h3": ["1.375rem", { lineHeight: "1.9rem" }],
         "mobile-body": ["1.125rem", { lineHeight: "1.65rem" }],
         "mobile-small": ["1rem", { lineHeight: "1.5rem" }],


### PR DESCRIPTION
## Summary
- уменьшил мобильный кегль hero-заголовка, чтобы фраза помещалась в две строки
- выровнял мобильные размеры секционных заголовков под размер шрифта карточек проектов
- чуть уменьшил заголовки карточек проектов, сохраняя визуальную иерархию на мобильных

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c0df82ac83218623176d9f50da1b)