### PR TITLE
Добавить мобильный раскрывающийся блок и обновить размеры текста

### DIFF
--- a/components/sections/DetToDetaiBridge.tsx
+++ b/components/sections/DetToDetaiBridge.tsx
@@ -1,5 +1,5 @@
 import BodyText from "../ui/BodyText";
-import DetDetaiMobileCard from "../ui/DetDetaiMobileCard";
+import MobileExpandableText from "../ui/MobileExpandableText";
 import HeadingLevel2 from "../ui/HeadingLevel2";
 import Section from "../ui/Section";
 
@@ -24,7 +24,7 @@ export default function DetToDetaiBridge() {
           ))}
         </div>
 
-        <DetDetaiMobileCard className="md:hidden" paragraphs={paragraphs} />
+        <MobileExpandableText className="md:hidden" paragraphs={paragraphs} />
       </div>
     </Section>
   );

--- a/components/sections/FundamentDetSection.tsx
+++ b/components/sections/FundamentDetSection.tsx
@@ -1,25 +1,32 @@
 import Button from "../ui/Button";
 import BodyText from "../ui/BodyText";
 import HeadingLevel2 from "../ui/HeadingLevel2";
+import MobileExpandableText from "../ui/MobileExpandableText";
 import Section from "../ui/Section";
 
 export default function FundamentDetSection() {
+  const paragraphs = [
+    "✨ DET — это культурная и методологическая рамка, которая помогает видеть человека в его глубине, движении и внутренней диалектике. Это надшкольный способ мышления, соединяющий экзистенциальную психологию, исследовательскую позицию и культуру присутствия.",
+    "Фундамент DET опирается на четыре уровня: концепцию, метод, платформу и проектную архитектуру. Вместе они образуют целостную систему, где смысл и практика поддерживают друг друга. Если тебе откликается идея внутренней честности, развития и диалектики — здесь начинается вход в глубинную часть DET.",
+  ];
+
   return (
     <Section id="fundament-det">
       <div className="flex flex-col gap-mobile-6 md:gap-8">
         <HeadingLevel2>Фундамент DET</HeadingLevel2>
-        <div className="space-y-mobile-4 md:space-y-6">
-          <BodyText variant="sectionDefaultOnLight">
-            ✨ DET — это культурная и методологическая рамка, которая помогает видеть человека в его глубине, движении и внутренней
-            диалектике. Это надшкольный способ мышления, соединяющий экзистенциальную психологию, исследовательскую позицию и
-            культуру присутствия.
-          </BodyText>
-          <BodyText variant="sectionDefaultOnLight">
-            Фундамент DET опирается на четыре уровня: концепцию, метод, платформу и проектную архитектуру. Вместе они образуют
-            целостную систему, где смысл и практика поддерживают друг друга. Если тебе откликается идея внутренней честности,
-            развития и диалектики — здесь начинается вход в глубинную часть DET.
-          </BodyText>
+        <div className="hidden flex-col space-y-6 md:flex">
+          {paragraphs.map((paragraph) => (
+            <BodyText key={paragraph} variant="sectionDefaultOnLight">
+              {paragraph}
+            </BodyText>
+          ))}
         </div>
+
+        <MobileExpandableText
+          className="md:hidden"
+          paragraphs={paragraphs}
+          textVariant="sectionDefaultOnLight"
+        />
         <div className="flex flex-col gap-mobile-3 md:flex-row md:items-center md:gap-4">
           <Button as="a" href="/det" className="w-fit" variant="primary">
             DET концепция

--- a/components/ui/BodyText.tsx
+++ b/components/ui/BodyText.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
-type BodyTextVariant =
+export type BodyTextVariant =
   | "sectionDefaultDark" // обычный текст в тёмных секциях
   | "sectionDefaultOnLight" // обычный текст в светлых секциях
   | "sectionBrand" // акцентный текст в секциях
@@ -15,12 +15,14 @@ type BodyTextProps = {
   children: ReactNode;
 };
 
+const projectCardClasses = "text-mobile-small text-basic-dark md:text-base";
+
 const variantClasses: Record<BodyTextVariant, string> = {
   sectionDefaultDark: "text-mobile-body text-accent-soft md:text-xl md:leading-relaxed",
   sectionDefaultOnLight: "text-mobile-body text-basic-dark md:text-xl md:leading-relaxed",
   sectionBrand: "text-mobile-body text-accent-primary md:text-xl md:leading-relaxed",
-  projectCard: "text-mobile-small text-basic-dark md:text-base",
-  infoCard: "text-mobile-small text-basic-dark md:text-base md:leading-relaxed",
+  projectCard: projectCardClasses,
+  infoCard: projectCardClasses,
 };
 
 export default function BodyText({

--- a/components/ui/DefaultCard.tsx
+++ b/components/ui/DefaultCard.tsx
@@ -13,7 +13,7 @@ type DefaultCardProps = {
 const containerClasses =
   "flex h-full flex-col gap-mobile-3 rounded-xl border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-6";
 
-const titleClasses = "text-mobile-h3 md:text-3xl font-serif font-semibold text-basic-dark md:leading-snug";
+const titleClasses = "text-2xl leading-snug md:text-[2rem] md:leading-snug font-serif font-semibold text-basic-dark";
 
 export default function DefaultCard({
   title,

--- a/components/ui/MobileExpandableText.tsx
+++ b/components/ui/MobileExpandableText.tsx
@@ -3,14 +3,26 @@
 import { useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
-import BodyText from "./BodyText";
 
-type DetDetaiMobileCardProps = {
+import BodyText, { type BodyTextVariant } from "./BodyText";
+
+type MobileExpandableTextProps = {
   paragraphs: string[];
+  textVariant?: BodyTextVariant;
   className?: string;
+  textClassName?: string;
+  previewCharLimit?: number;
+  moreLabel?: string;
 };
 
-export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMobileCardProps) {
+export default function MobileExpandableText({
+  paragraphs,
+  textVariant = "infoCard",
+  className,
+  textClassName,
+  previewCharLimit = 320,
+  moreLabel = "Читать далее",
+}: MobileExpandableTextProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const { firstSentence, remainingParagraphs, remainingText } = useMemo(() => {
@@ -31,7 +43,7 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
     };
   }, [paragraphs]);
 
-  const previewText = useMemo(() => remainingText.slice(0, 320), [remainingText]);
+  const previewText = useMemo(() => remainingText.slice(0, previewCharLimit), [remainingText, previewCharLimit]);
   const previewParagraphs = useMemo(
     () => previewText.split(/\n\n+/).map((paragraph) => paragraph.trim()).filter(Boolean),
     [previewText],
@@ -40,7 +52,7 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
   return (
     <div
       className={cn(
-        "md:hidden relative isolate w-full max-w-none overflow-hidden bg-basic-light",
+        "md:hidden relative isolate w-full max-w-none overflow-hidden bg-basic-light", // mobile only
         className,
       )}
       role="button"
@@ -56,12 +68,14 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
       aria-label={isExpanded ? "Свернуть текст" : "Развернуть текст"}
     >
       <div className="relative z-10 flex flex-col gap-mobile-4 px-0 py-mobile-1">
-        <BodyText variant="infoCard" className="text-basic-dark">{firstSentence}</BodyText>
+        <BodyText variant={textVariant} className={textClassName}>
+          {firstSentence}
+        </BodyText>
 
         {isExpanded ? (
           <div className="flex flex-col gap-mobile-3">
             {remainingParagraphs.map((paragraph, index) => (
-              <BodyText key={index} variant="infoCard" className="text-basic-dark">
+              <BodyText key={index} variant={textVariant} className={textClassName}>
                 {paragraph}
               </BodyText>
             ))}
@@ -69,7 +83,7 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
         ) : previewParagraphs.length ? (
           <div className="flex flex-col gap-mobile-3">
             {previewParagraphs.map((paragraph, index) => (
-              <BodyText key={index} variant="infoCard" className="text-basic-dark">
+              <BodyText key={index} variant={textVariant} className={textClassName}>
                 {paragraph}
               </BodyText>
             ))}
@@ -81,7 +95,7 @@ export default function DetDetaiMobileCard({ paragraphs, className }: DetDetaiMo
         <>
           <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-20 bg-gradient-to-t from-basic-light via-basic-light/90 to-transparent" />
           <span className="pointer-events-none absolute bottom-mobile-3 right-mobile-4 z-10 text-mobile-small font-semibold uppercase tracking-wide text-accent-primary">
-            Читать дальше
+            {moreLabel}
           </span>
         </>
       ) : null}


### PR DESCRIPTION
## Summary
- ✨ Вынес мобильный механизм скрытия текста в компонент `MobileExpandableText` и применил его в блоках DET ↔ DETai и «Фундамент DET» на мобильных устройствах.
- 🎯 Увеличил заголовки карточек аудитории и привёл текст внутри карточек к размеру, используемому в карточках проектов.

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c1c62efc8321bc129741afd71737)