### PR TITLE
Добавлен meta viewport для корректного мобильного отображения

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "../styles/globals.css";
 import type { ReactNode } from "react";
+import type { Viewport } from "next";
 import { Lora, Open_Sans } from "next/font/google";
 
 import ShimmerAutoTrigger from "@/components/layout/ShimmerAutoTrigger";
@@ -21,6 +22,11 @@ const lora = Lora({
 export const metadata = {
   title: "DETai Site",
   description: "Dialectical Existential Therapy and DETai ecosystem",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- ✨ Добавлен viewport с width=device-width и initial-scale=1, чтобы мобильные классы Tailwind корректно применялись

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c27f2ca8832194ed6d15fa1a1c97)