### PR TITLE
Refactor mobile heading typography

### DIFF
--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -50,7 +50,7 @@ export default function Projects() {
             className="group flex h-full flex-col gap-mobile-3 rounded-lg border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-5"
             href={project.href}
           >
-            <div className="flex items-center gap-mobile-3 text-mobile-h3 font-serif font-semibold text-basic-dark md:gap-3 md:text-lg md:leading-tight">
+            <div className="flex items-center gap-mobile-3 text-xl font-serif font-semibold text-basic-dark md:gap-3 md:text-lg md:leading-tight">
               <span aria-hidden>{project.icon}</span>
               <span>{project.name}</span>
             </div>

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -21,9 +21,9 @@ export default function Heading({
   const Tag = `h${level}` as const;
 
   const levelClasses: Record<HeadingLevel, string> = {
-    1: "text-mobile-h1 md:text-5xl font-serif font-semibold tracking-tight md:leading-tight",
-    2: "text-mobile-h2 md:text-4xl font-serif font-medium tracking-normal md:font-semibold md:tracking-tight md:leading-snug",
-    3: "text-mobile-h3 md:text-3xl font-serif font-semibold tracking-tight md:leading-snug",
+    1: "text-3xl md:text-5xl font-serif font-semibold tracking-tight md:leading-tight",
+    2: "text-2xl md:text-4xl font-serif font-medium tracking-normal md:font-semibold md:tracking-tight md:leading-snug",
+    3: "text-xl md:text-3xl font-serif font-semibold tracking-tight md:leading-snug",
   };
 
   const colorClasses: Record<HeadingColor, string> = {

--- a/components/ui/HeroHeadingTitle.tsx
+++ b/components/ui/HeroHeadingTitle.tsx
@@ -10,7 +10,7 @@ type HeroHeadingTitleProps = {
 
 export default function HeroHeadingTitle({ children, className }: HeroHeadingTitleProps) {
   return (
-    <Heading level={1} color="soft" className={cn("text-mobile-hero md:text-5xl", className)}>
+    <Heading level={1} color="soft" className={cn("text-4xl md:text-5xl", className)}>
       {children}
     </Heading>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,10 +47,6 @@ module.exports = {
       },
       fontSize: {
         // Mobile semantic typography
-        "mobile-hero": ["2.25rem", { lineHeight: "2.8rem" }],
-        "mobile-h1": ["2rem", { lineHeight: "2.4rem" }],
-        "mobile-h2": ["1.5rem", { lineHeight: "2rem" }],
-        "mobile-h3": ["1.375rem", { lineHeight: "1.9rem" }],
         "mobile-body": ["1.125rem", { lineHeight: "1.65rem" }],
         "mobile-small": ["1rem", { lineHeight: "1.5rem" }],
       },


### PR DESCRIPTION
🚀 Упростил мобильную типографику заголовков на дефолтные классы Tailwind для наглядного контроля.

## Summary
- удалил кастомные мобильные токены заголовков из tailwind.config.js, оставив остальные настройки без изменений
- перевёл компонент Heading и связанные заголовки на стандартные размеры Tailwind для мобильных экранов
- обновил потребители заголовков, чтобы использовать новые классы

## Testing
- npm run lint (есть прежние предупреждения по зависимостям useEffect в Canvas слоях)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c769deec8321a9c989a5f79b47a0)