### PR TITLE
Fix scan border sizing

### DIFF
--- a/styles/project-cards.css
+++ b/styles/project-cards.css
@@ -54,12 +54,14 @@
 .detai-scan-border {
   position: relative;
   isolation: isolate;
+  overflow: hidden;
 }
 
 .detai-scan-border::before {
   content: "";
   position: absolute;
   inset: 0;
+  box-sizing: border-box;
   padding: 2px;
   border-radius: inherit;
   background: conic-gradient(


### PR DESCRIPTION
## Изменения
- ✨ Добавил `box-sizing: border-box` и скрыл переполнение у `.detai-scan-border`, чтобы анимация светового луча не меняла ширину контейнера.

## Тесты
- не запускались (не требовалось)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e780013c83219a50e56bb6cf5f0c)