### PR TITLE
Fix echelon carousel hover and gradient

### DIFF
--- a/components/sections/ProjectsListSection.tsx
+++ b/components/sections/ProjectsListSection.tsx
@@ -59,7 +59,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
           <button
             type="button"
             onClick={() => scrollByCardWidth("left")}
-            className="rounded-full border border-accent-primary/30 bg-basic-dark/40 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
+            className="rounded-full border border-accent-primary/30 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:bg-basic-dark/20 hover:text-accent-soft/90"
             aria-label="Прокрутить влево"
           >
             ←
@@ -67,7 +67,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
           <button
             type="button"
             onClick={() => scrollByCardWidth("right")}
-            className="rounded-full border border-accent-primary/30 bg-basic-dark/40 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
+            className="rounded-full border border-accent-primary/30 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:bg-basic-dark/20 hover:text-accent-soft/90"
             aria-label="Прокрутить вправо"
           >
             →
@@ -76,20 +76,20 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
       </div>
 
       <div className="relative">
-        <div className="overflow-hidden pr-8 md:pr-12">
-          <div
-            ref={scrollRef}
-            className="flex gap-mobile-4 overflow-x-auto overflow-y-hidden scroll-smooth pb-3 md:gap-5"
-          >
+        <div className="overflow-x-auto scroll-smooth pb-4 pr-8 md:pb-5 md:pr-12">
+          <div ref={scrollRef} className="flex gap-mobile-4 md:gap-5">
             {items.map((project) => (
-              <div key={project.id} className="w-[85%] min-w-[260px] max-w-[320px] flex-shrink-0 md:w-[320px] md:max-w-[320px]">
+              <div
+                key={project.id}
+                className="w-[85%] min-w-[260px] max-w-[320px] flex-shrink-0 pt-1 md:w-[320px] md:max-w-[320px] md:pt-2"
+              >
                 <ProjectCard {...project} />
               </div>
             ))}
           </div>
         </div>
 
-        <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-basic-dark via-basic-dark/70 to-transparent md:w-20" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-basic-dark/90 via-basic-dark/60 to-transparent md:w-20" />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 Кратко
- ✨ Карусель проектов больше не обрезает 3D-hover карточек, добавлены отступы для безопасного наклона.
- 🌗 Градиент справа теперь мягче и слит с фоном секции, без ощущения отдельной подложки.
- 🧭 Кнопки прокрутки без лишнего тёмного фона, сохраняя акцентный обводящий стиль.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947253ade3c8321a343531446f7e036)