### PR TITLE
Фикс отступа между описанием и эшелонами на мобильных

### DIFF
--- a/components/sections/ProjectsListSection.tsx
+++ b/components/sections/ProjectsListSection.tsx
@@ -118,7 +118,7 @@ export default function ProjectsListSection({ containerClassName }: ProjectsList
           containerClassName,
         )}
       >
-        <div className="flex flex-col gap-mobile-5 md:gap-10">
+        <div className="flex flex-col gap-mobile-6 md:gap-10">
           <div className="flex flex-col gap-mobile-2 md:gap-3">
             <HeadingLevel2 color="soft">Каталог проектов DETai</HeadingLevel2>
             <BodyText variant="sectionDefaultDark" className="max-w-3xl text-accent-soft/80">


### PR DESCRIPTION
## Изменения
- 📱 Увеличен вертикальный отступ между описанием каталога проектов и первым эшелоном на мобильных, чтобы блоки не слипались.

## Тесты
- ⏩ Не запускались (визуальный фикс)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694727bc0d7483218e6545bcf2833b51)