### PR TITLE
Убрать прозрачность в секции списка проектов

### DIFF
--- a/components/sections/ProjectsListSection.tsx
+++ b/components/sections/ProjectsListSection.tsx
@@ -59,7 +59,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
           <button
             type="button"
             onClick={() => scrollByCardWidth("left")}
-            className="rounded-full border border-accent-primary/30 bg-basic-dark/40 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
+            className="rounded-full border border-accent-primary/30 bg-basic-dark px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
             aria-label="Прокрутить влево"
           >
             ←
@@ -67,7 +67,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
           <button
             type="button"
             onClick={() => scrollByCardWidth("right")}
-            className="rounded-full border border-accent-primary/30 bg-basic-dark/40 px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
+            className="rounded-full border border-accent-primary/30 bg-basic-dark px-3 py-2 text-accent-soft transition-colors duration-150 hover:border-accent-primary/50 hover:text-accent-soft/90"
             aria-label="Прокрутить вправо"
           >
             →
@@ -89,7 +89,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
           </div>
         </div>
 
-        <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-basic-dark via-basic-dark/70 to-transparent md:w-20" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-basic-dark via-basic-dark to-transparent md:w-20" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- убраны полупрозрачные фоны у кнопок навигации в ProjectsListSection, теперь цвет совпадает с фоном секции
- убран полупрозрачный градиент затенения, чтобы блок выглядел как единое полотно basic.dark

## Testing
- Not run (not requested)

## Комментарий
🎨 Кнопки и градиент теперь слиты с фоном секции — без лишних подложек и полупрозрачности.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694839afffbc8321a81938e6c74e0648)