### PR TITLE
Расширить подложку списка проектов

### DIFF
--- a/components/sections/ProjectsListSection.tsx
+++ b/components/sections/ProjectsListSection.tsx
@@ -76,7 +76,7 @@ function EchelonRow({ echelon, items }: { echelon: Project["echelon"]; items: Pr
       </div>
 
       <div className="relative -mx-mobile-4 md:-mx-10">
-        <div className="bg-basic-dark px-mobile-4 pr-8 md:px-10 md:pr-16">
+        <div className="bg-basic-dark px-mobile-5 pr-8 pt-mobile-4 md:px-12 md:pr-16 md:pt-6">
           <div
             ref={scrollRef}
             className="flex gap-mobile-4 overflow-x-auto overflow-y-visible scroll-smooth pb-4 md:gap-6"


### PR DESCRIPTION
## Изменения
- 🧭 Добавил дополнительный верхний и левый отступ подложки карусели проектов, чтобы карточки получили больший зазор.

## Тесты
- ✅ `npm run lint`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483b8eb6bc8321946ab3bacb86d1d2)