### PR TITLE
Добавить hero и ценности для страницы DET

### DIFF
--- a/app/(det)/det/page.tsx
+++ b/app/(det)/det/page.tsx
@@ -1,23 +1,15 @@
-import BodyText from "@/components/ui/BodyText";
 import Footer from "@/components/layout/Footer";
 import Header from "@/components/layout/Header";
-import Heading from "@/components/ui/Heading";
-import Section from "@/components/ui/Section";
+import DetHero from "@/components/sections/DetHero";
+import DetValues from "@/components/sections/DetValues";
 
 export default function Page() {
   return (
     <div className="flex min-h-screen flex-col bg-basic-light text-basic-dark">
       <Header />
       <main className="flex flex-1 flex-col">
-        <Section>
-          <div className="flex flex-col gap-mobile-4 md:gap-6">
-            <Heading level={1}>DET</Heading>
-            <BodyText className="text-basic-dark md:text-xl md:leading-relaxed">
-              Здесь появится главная страница направления DET: концепции, методология и навигация по ключевым материалам. Страница
-              в разработке — скоро добавим подробности, чтобы можно было перейти к нужным разделам.
-            </BodyText>
-          </div>
-        </Section>
+        <DetHero />
+        <DetValues />
       </main>
       <Footer />
     </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -15,8 +15,8 @@ export default function Header() {
           >
             Проекты
           </a>
-          <a className="hover:text-accent-primary" href="#fundament-det">
-            Ядро DET
+          <a className="hover:text-accent-primary" href="/det">
+            DET
           </a>
           <a className="hover:text-accent-primary" href="#mission">
             Миссия

--- a/components/sections/DetHero.tsx
+++ b/components/sections/DetHero.tsx
@@ -1,0 +1,31 @@
+import BodyText from "../ui/BodyText";
+import Heading from "../ui/Heading";
+import Section from "../ui/Section";
+import HeroScene from "./HeroScene";
+
+export default function DetHero() {
+  return (
+    <Section
+      id="det-hero"
+      variant="light"
+      className="relative overflow-hidden bg-accent-soft"
+      containerClassName="relative grid min-h-[70vh] grid-cols-1 items-center gap-8 md:min-h-[80vh] md:grid-cols-[minmax(28rem,0.9fr)_minmax(24rem,1.1fr)] md:gap-12"
+      fullWidth
+    >
+      <div className="order-2 flex flex-col gap-mobile-3 md:order-1 md:gap-6">
+        <Heading level={1} className="text-4xl md:text-5xl">
+          DET — Dialectical Existential Therapy.
+        </Heading>
+
+        <BodyText variant="sectionDefaultOnLight" className="text-lg md:text-xl md:leading-relaxed">
+          Внутренняя двойственность — наш дар, а не наш баг.
+          <br />
+          <br />
+          Единство и борьба противоположностей — не то, что ломает, а то, что делает нас сильнее.
+        </BodyText>
+      </div>
+
+      <HeroScene className="order-1 flex min-h-[22rem] flex-col items-center justify-center rounded-2xl border border-accent-primary/30 bg-basic-light/70 px-mobile-4 py-mobile-6 shadow-lg md:order-2 md:min-h-[30rem] md:px-8 md:py-10 lg:min-h-[34rem]" />
+    </Section>
+  );
+}

--- a/components/sections/DetValues.tsx
+++ b/components/sections/DetValues.tsx
@@ -1,0 +1,47 @@
+import BodyText from "../ui/BodyText";
+import DefaultCard from "../ui/DefaultCard";
+import Heading from "../ui/Heading";
+import Section from "../ui/Section";
+
+const detValues = [
+  {
+    title: "Ценность диалектически-экзистенциальной терапии",
+    description:
+      "Первая ценность DET — уважение к внутренней двойственности человека. Мы не пытаемся “исправить” внутрений конфликт и противоречия как дефект: мы учимся видеть в них динамику, смысл и возможность для роста.",
+  },
+  {
+    title: "Безусловная вера во внутренний потенциал",
+    description:
+      "Вторая ценность — безусловная вера во внутренний потенциал личности. В человеке уже заложено все потенциально возможное — и наша задача помочь проявиться тому, что может сделать жизнь глубже, честнее и устойчивее.",
+  },
+];
+
+export default function DetValues() {
+  return (
+    <Section
+      id="det-values"
+      variant="dark"
+      className="bg-basic-dark"
+      containerClassName="flex flex-col gap-mobile-5 md:gap-10"
+    >
+      <div className="flex flex-col gap-mobile-3 md:gap-4">
+        <Heading level={2} color="soft">
+          Ценности DET
+        </Heading>
+        <BodyText className="max-w-3xl">
+          Ценности диалектически-экзистенциальной терапии
+        </BodyText>
+      </div>
+
+      <div className="grid grid-cols-1 gap-mobile-4 md:grid-cols-2 md:gap-6">
+        {detValues.map((value) => (
+          <DefaultCard key={value.title} title={value.title} variant="dark">
+            <BodyText className="text-mobile-body text-accent-soft md:text-xl md:leading-relaxed">
+              {value.description}
+            </BodyText>
+          </DefaultCard>
+        ))}
+      </div>
+    </Section>
+  );
+}

--- a/components/ui/DefaultCard.tsx
+++ b/components/ui/DefaultCard.tsx
@@ -8,22 +8,34 @@ type DefaultCardProps = {
   title: string;
   children: ReactNode;
   className?: string;
+  variant?: "light" | "dark";
 };
 
-const containerClasses =
-  "flex h-full flex-col gap-mobile-3 rounded-xl border border-accent-primary/30 bg-accent-soft p-mobile-4 text-basic-dark shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:border-accent-primary hover:shadow-lg md:gap-4 md:p-6";
+const baseContainerClasses =
+  "flex h-full flex-col gap-mobile-3 rounded-xl border p-mobile-4 shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg md:gap-4 md:p-6";
 
-const titleClasses =
-  "min-h-[3.5rem] text-xl leading-snug md:min-h-[5.5rem] md:text-[2rem] md:leading-snug font-serif font-semibold text-basic-dark";
+const variantContainerClasses: Record<NonNullable<DefaultCardProps["variant"]>, string> = {
+  light: "border-accent-primary/30 bg-accent-soft text-basic-dark hover:border-accent-primary",
+  dark: "border-accent-primary/40 bg-basic-dark text-accent-soft shadow-md hover:border-accent-primary",
+};
+
+const baseTitleClasses =
+  "min-h-[3.5rem] text-xl leading-snug md:min-h-[5.5rem] md:text-[2rem] md:leading-snug font-serif font-semibold";
+
+const variantTitleClasses: Record<NonNullable<DefaultCardProps["variant"]>, string> = {
+  light: "text-basic-dark",
+  dark: "text-accent-soft",
+};
 
 export default function DefaultCard({
   title,
   children,
   className,
+  variant = "light",
 }: DefaultCardProps) {
   return (
-    <div className={cn(containerClasses, className)}>
-      <Heading level={3} className={titleClasses}>
+    <div className={cn(baseContainerClasses, variantContainerClasses[variant], className)}>
+      <Heading level={3} className={cn(baseTitleClasses, variantTitleClasses[variant])}>
         {title}
       </Heading>
       {children}

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -68,5 +68,7 @@ shimmer — это фирменная фича primary.
 ## DefaultCard.tsx
 
 * Базовая карточка с рамкой, мягким фоном и hover-подъёмом.
-* Принимает `title`, `children`, опционально `className` и `titleAs` (`h3` | `h4`).
-* Сохраняет вертикальный ритм: gap мобильный/desktop, отступы `p-mobile-4` → `md:p-6`, рамку `border-accent-primary/30` и тень `shadow-sm` → `hover:shadow-lg` с лёгким сдвигом вверх.
+* Принимает `title`, `children`, опционально `className`, `titleAs` (`h3` | `h4`) и `variant` (`light` | `dark`).
+* Сохраняет вертикальный ритм: gap мобильный/desktop, отступы `p-mobile-4` → `md:p-6`, тень `shadow-sm` → `hover:shadow-lg` с лёгким сдвигом вверх.
+  * `variant="light"` (значение по умолчанию) — мягкий светлый фон `bg-accent-soft`, граница `border-accent-primary/30`, текст тёмный.
+  * `variant="dark"` — фон `bg-basic-dark`, текст `text-accent-soft`, усиленная граница `border-accent-primary/40`.


### PR DESCRIPTION
## 📝 Изменения
- ✨ Добавлен светлый hero-блок DET на /det.
- 🌗 Создан тёмный блок «Ценности DET» с двумя карточками и новой тёмной темой DefaultCard.
- 🧭 Обновлена навигация хедера и описание DefaultCard в документации.

## ✅ Тесты
- `npm run lint` (есть предупреждения от существующих хук-правил ESLint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694897d636dc8321947158dbcfac835c)