### PR TITLE
Добавить нумерацию карточек ценностей DET

### DIFF
--- a/components/sections/DetValues.tsx
+++ b/components/sections/DetValues.tsx
@@ -9,12 +9,12 @@ const detValues = [
   {
     title: "Право на противоречие",
     description:
-      "Уважение к внутренней двойственности человека. Мы не пытаемся “исправить” внутренний конфликт и противоречия как дефект: мы учимся видеть в них динамику, смысл и возможность для роста.",
+      "Уважение к внутренней двойственности человека.\u00a0\u00a0Мы не пытаемся “исправить” внутренний конфликт и противоречия как дефект: мы учимся видеть в них динамику, смысл и возможность для роста.",
   },
   {
     title: "Безусловная вера во внутренний потенциал",
     description:
-      "Безусловная вера во внутренний потенциал личности. В человеке уже заложено все потенциально возможное — и наша задача помочь проявиться тому, что может сделать жизнь глубже, честнее и устойчивее.",
+      "Безусловная вера во внутренний потенциал личности.\u00a0\u00a0В человеке уже заложено все потенциально возможное — и наша задача помочь проявиться тому, что может сделать жизнь глубже, честнее и устойчивее.",
   },
 ];
 
@@ -41,17 +41,18 @@ export default function DetValues() {
             key={value.title}
             title={value.title}
             variant="dark"
-            titlePrefixPlacement="top-right"
+            className="gap-mobile-2 md:gap-3"
+            titleClassName="min-h-0 text-left text-xl leading-snug md:min-h-0 md:text-[2rem] md:leading-snug"
+            titlePrefixPlacement="top-left"
             titlePrefix={
               <Image
                 alt={`Золотая цифра ${index + 1}`}
-                className="h-16 w-16 md:h-14 md:w-14"
-                height={64}
+                className="h-20 w-20 md:h-[5.5rem] md:w-[5.5rem]"
+                height={88}
                 src={`/images/gold_numbers/${index + 1}_number.webp`}
-                width={64}
+                width={88}
               />
             }
-            titleClassName="text-left text-xl leading-snug md:text-lg md:leading-tight"
           >
             <BodyText className="text-left text-mobile-body text-accent-soft md:text-base md:leading-relaxed">
               {value.description}

--- a/components/ui/DefaultCard.tsx
+++ b/components/ui/DefaultCard.tsx
@@ -11,11 +11,11 @@ type DefaultCardProps = {
   variant?: "light" | "dark";
   titlePrefix?: ReactNode;
   titleClassName?: string;
-  titlePrefixPlacement?: "inline" | "top-right";
+  titlePrefixPlacement?: "inline" | "top-right" | "top-left";
 };
 
 const baseContainerClasses =
-  "flex h-full flex-col gap-mobile-3 rounded-xl border p-mobile-4 shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg md:gap-4 md:p-6";
+  "flex h-full flex-col gap-mobile-2 rounded-xl border p-mobile-4 shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg md:gap-3 md:p-6";
 
 const variantContainerClasses: Record<NonNullable<DefaultCardProps["variant"]>, string> = {
   light: "border-accent-primary/30 bg-accent-soft text-basic-dark hover:border-accent-primary",
@@ -39,13 +39,22 @@ export default function DefaultCard({
   titleClassName,
   titlePrefixPlacement = "inline",
 }: DefaultCardProps) {
-  const isTopRightPrefix = titlePrefix && titlePrefixPlacement === "top-right";
+  const isTopCornerPrefix =
+    titlePrefix && (titlePrefixPlacement === "top-right" || titlePrefixPlacement === "top-left");
+  const isTopLeftPrefix = titlePrefix && titlePrefixPlacement === "top-left";
 
   return (
     <div className={cn(baseContainerClasses, variantContainerClasses[variant], className)}>
-      {isTopRightPrefix ? (
+      {isTopCornerPrefix ? (
         <div className="flex flex-col gap-mobile-2 md:gap-3">
-          <div className="flex w-full justify-end pt-mobile-1 pr-mobile-1 md:pt-2 md:pr-2">
+          <div
+            className={cn(
+              "flex w-full pt-mobile-1 md:pt-2",
+              isTopLeftPrefix
+                ? "justify-start pl-mobile-1 md:pl-2"
+                : "justify-end pr-mobile-1 md:pr-2",
+            )}
+          >
             {titlePrefix}
           </div>
           <Heading


### PR DESCRIPTION
## Изменения
- ✨ Добавлены золотые цифры-аватарки для карточек ценностей с изображениями из `public/images/gold_numbers`.
- 🎯 Приведены размеры заголовков и текста карточек к стилю блока «Проекты DETai».

## Тесты
- ✅ `npm run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949bf8c29888321bcbc9db051dcf7c9)