### PR TITLE
Увеличен отступ карточек ценностей на мобильной версии

### DIFF
--- a/components/sections/DetValues.tsx
+++ b/components/sections/DetValues.tsx
@@ -24,7 +24,7 @@ export default function DetValues() {
       id="det-values"
       variant="dark"
       className="bg-basic-dark"
-      containerClassName="flex flex-col gap-mobile-5 md:gap-10"
+      containerClassName="flex flex-col gap-mobile-6 md:gap-10"
     >
       <div className="flex flex-col gap-mobile-3 md:gap-4">
         <Heading level={2} color="soft">


### PR DESCRIPTION
## Изменения
- 📱 Увеличил мобильный отступ между блоком заголовка и карточками в секции ценностей, чтобы верхний край карточек не прилипал.

## Тесты
- ✅ `npm run lint` (есть существующие предупреждения от eslint о зависимостях useEffect).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c541433c8321b3672e844471c53f)