### PR TITLE
Tune mobile typography for scientific publications

### DIFF
--- a/components/sections/DetScience.tsx
+++ b/components/sections/DetScience.tsx
@@ -123,7 +123,7 @@ export default function DetScience() {
               aria-controls={`det-tabpanel-${tab.id}`}
               type="button"
               className={cn(
-                "whitespace-nowrap rounded-full border px-4 py-2 text-mobile-small font-semibold transition-colors duration-200",
+                "whitespace-nowrap rounded-full border px-3 py-1.5 text-sm font-semibold transition-colors duration-200 md:px-4 md:py-2 md:text-mobile-small",
                 activeTab === tab.id
                   ? "border-accent-primary/50 bg-accent-soft text-basic-dark shadow-sm"
                   : "border-basic-dark/10 bg-basic-light text-basic-dark hover:border-basic-dark/30"
@@ -176,7 +176,7 @@ function PublicationList({ id, labelledBy, publications }: PublicationListProps)
             <div className="flex flex-col gap-mobile-2 md:flex-row md:items-start md:justify-between">
               <Link
                 href={publication.href}
-                className="text-lg font-semibold text-basic-dark underline decoration-accent-primary/50 underline-offset-[6px] transition-colors duration-200 hover:text-accent-hover md:text-xl"
+                className="text-base font-semibold text-basic-dark underline decoration-accent-primary/50 underline-offset-[6px] transition-colors duration-200 hover:text-accent-hover md:text-xl"
               >
                 {publication.title}
               </Link>
@@ -194,8 +194,8 @@ function PublicationList({ id, labelledBy, publications }: PublicationListProps)
                 </div>
               )}
             </div>
-            <p className="text-mobile-small text-basic-dark md:text-lg md:leading-relaxed">
-              <span className="italic">{publication.venue}</span>
+            <p className="text-sm text-basic-dark md:text-lg md:leading-relaxed">
+              <span className="text-xs italic md:text-lg">{publication.venue}</span>
               {publication.authors ? ` — ${publication.authors}` : null} —
               <span className="font-medium"> {publication.year}</span>
             </p>


### PR DESCRIPTION
## Summary
- 📱 уменьшен мобильный размер заголовков статей и журналов в блоке «Научная обоснованность», чтобы текст выглядел компактнее
- 🔘 уменьшены размеры кнопок переключения вкладок публикаций на мобильной версии

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c5ed315c8321bb3fe1b6fd53ad11)