### PR TITLE
Скрыть содержимое `wordpress-data` в `Directory_structure.txt`

### DIFF
--- a/personal-site/Directory_structure.txt
+++ b/personal-site/Directory_structure.txt
@@ -1,22 +1,40 @@
 .
-├── README.md
-├── Directory_structure.txt
-├── app/                          # Страницы и маршруты
-├── components/                   # UI-компоненты
-├── lib/                          # Логика и данные
+├── app/
+│   ├── blog/
+│   │   ├── [slug]/
+│   │   │   └── page.tsx
+│   │   └── page.tsx
+│   ├── globals.css
+│   ├── layout.tsx
+│   └── page.tsx
+├── components/
+│   └── layout/
+│       └── Header.tsx
+├── lib/
 │   └── blog/
+│       ├── posts/
+│       │   └── eta-istoriya-pro-odnogo-cheloveka.md
 │       ├── README.md
 │       ├── blog.base.ts
 │       ├── blog.client.ts
 │       ├── blog.data.ts
 │       ├── blog.description.ts
 │       ├── blog.utils.ts
-│       ├── posts/
 │       └── types.ts
-├── public/                       # Публичные файлы (картинки постов и т.д.)
-├── scripts/                      # Скрипты миграции
-├── wordpress-data/               # Экспорт WordPress и вложения
+├── public/
+│   └── images/
+│       └── posts/
+│           ├── eta-istoriya-pro-odnogo-cheloveka.svg
+│           └── maxresdefault.jpg
+├── scripts/
+│   ├── extract-posts.ts
+│   ├── migrate-wordpress.ts
+│   └── optimize-images.ts
+├── wordpress-data/ (внутри несколько тысяч файлов)
+├── .gitignore
+├── Directory_structure.txt
+├── README.md
+├── next-env.d.ts
 ├── next.config.js
 ├── package.json
-├── tsconfig.json
-└── next-env.d.ts
+└── tsconfig.json


### PR DESCRIPTION
### Motivation
- Убрать развёрнутый список тысяч файлов из описательной структуры проекта, чтобы файл был компактнее и удобнее для чтения.
- Избежать включения в документацию огромного объёма данных, не относящихся к коду.
- Сохранить пометку о наличии большого количества файлов в `wordpress-data/` для контекста.

### Description
- Перегенерирован файл `personal-site/Directory_structure.txt`, из которого удалено детальное перечисление содержимого папки `wordpress-data/` и добавлена пометка `(внутри несколько тысяч файлов)`.
- Обновлён вывод структуры для ключевых подпапок `app/`, `lib/`, `public/` и `scripts/` без изменения исходного кода сайта.
- Изменения касаются только описательного файла `personal-site/Directory_structure.txt`, код проекта не затронут.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601a0cf7388321957ed77dc8cc1042)