### PR TITLE
Добавить alternates.languages для страниц блога

### DIFF
--- a/personal-site/app/[lang]/blog/[slug]/page.tsx
+++ b/personal-site/app/[lang]/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 
-import { getPostByLangAndSlug } from "../../../../lib/blog/blog.data";
+import { getAvailableLangsForPost, getPostByLangAndSlug } from "../../../../lib/blog/blog.data";
 import { isLang } from "../../../../lib/blog/blog.i18n";
 
 interface BlogPostPageProps {
@@ -11,6 +11,37 @@ interface BlogPostPageProps {
 }
 
 export const runtime = "nodejs";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+
+export async function generateMetadata({ params }: BlogPostPageProps) {
+  if (!isLang(params.lang)) {
+    notFound();
+  }
+
+  const post = await getPostByLangAndSlug(params.lang, params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const languages = getAvailableLangsForPost(post.id).reduce<Record<string, string>>(
+    (acc, lang) => {
+      acc[lang] = `/${lang}/blog/${post.slugs[lang]}`;
+      return acc;
+    },
+    {}
+  );
+
+  return {
+    title: post.titles[params.lang],
+    description: post.excerpt,
+    metadataBase: new URL(siteUrl),
+    alternates: {
+      languages,
+    },
+  };
+}
 
 export async function generateStaticParams() {
   const { baseBlogPosts } = await import("../../../../lib/blog/blog.base");

--- a/personal-site/app/[lang]/blog/page.tsx
+++ b/personal-site/app/[lang]/blog/page.tsx
@@ -10,12 +10,29 @@ interface BlogPageProps {
   };
 }
 
-export const metadata = {
-  title: "Блог",
-  description: "Посты блога",
-};
-
 export const runtime = "nodejs";
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+
+export function generateMetadata({ params }: BlogPageProps) {
+  if (!isLang(params.lang)) {
+    notFound();
+  }
+
+  const languages = supportedLangs.reduce<Record<string, string>>((acc, lang) => {
+    acc[lang] = `/${lang}/blog`;
+    return acc;
+  }, {});
+
+  return {
+    title: "Блог",
+    description: "Посты блога",
+    metadataBase: new URL(siteUrl),
+    alternates: {
+      languages,
+    },
+  };
+}
 
 export function generateStaticParams() {
   return supportedLangs.map((lang) => ({ lang }));


### PR DESCRIPTION
### Motivation
- Добавить корректные альтернативные URL для SEO и мульти-язычности на страницах списка постов и страницах постов. 
- Генерировать абсолютные URL через `metadataBase`, чтобы Next.js формировал полные ссылки в метаданных. 
- Использовать доступные языки поста из бизнес-логики (`getAvailableLangsForPost`) для формирования `alternates.languages`. 
- Обрабатывать случаи отсутствия языка/поста через `notFound()`.

### Description
- В `personal-site/app/[lang]/blog/page.tsx` добавлен `generateMetadata` который собирает `alternates.languages` для всех `supportedLangs` и устанавливает `metadataBase` на основе `NEXT_PUBLIC_SITE_URL`.
- В `personal-site/app/[lang]/blog/[slug]/page.tsx` добавлен `generateMetadata`, который загружает пост через `getPostByLangAndSlug`, формирует `alternates.languages` по результату `getAvailableLangsForPost(post.id)` и возвращает заголовок/описание поста.
- Значение базового домена читается из `process.env.NEXT_PUBLIC_SITE_URL` с паддингом по умолчанию `http://localhost:3000` и используется в `metadataBase`.
- Для некорректного `lang` или отсутствующих данных `generateMetadata` вызывает `notFound()`.

### Testing
- Автоматические тесты не запускались.
- Локальная сборка/линтер не запускались в рамках этого PR.
- Изменения покрыты ручной проверкой файлов в репозитории (см. модифицированные файлы `personal-site/app/[lang]/blog/page.tsx` и `personal-site/app/[lang]/blog/[slug]/page.tsx`).
- Нет регрессионных тестов, связанных с метаданными, в текущем CI для этих изменений.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612645b89c8321aaece59b9902c048)