### PR TITLE
Привести таксономии к единичным полям и добавить keywords

### DIFF
--- a/personal-site/lib/blog/README.md
+++ b/personal-site/lib/blog/README.md
@@ -19,7 +19,7 @@
 
 1. Сохраните текст поста в `lib/blog/posts/<postId>/<lang>.md`.
 2. Скопируйте обложку из `wordpress-data/uploads`, оптимизируйте её и положите в `public/images/posts/`. Если WebP нельзя добавить в PR, используйте временный SVG и сохраните WebP отдельно.
-3. Заполните метаданные в `blog.base.ts`: `title`, `publishedAt`, `categories`, `tags`, `coverImage`, `slugs`, `contentFiles`.
+3. Заполните метаданные в `blog.base.ts`: `title`, `publishedAt`, `rubric` (одна рубрика на пост), `category` (одна категория на пост), `keywords`, `keywordsRaw`, `coverImage`, `slugs`, `contentFiles`.
 
 [⬅ Вернуться к основному README](../../README.md)
 
@@ -48,6 +48,10 @@
   * `id` — внутренний идентификатор;
   * `slugs` — локализованные slug’и для каждого языка;
   * `titles` — локализованные заголовки (с fallback на default);
+  * `rubric` — рубрика поста (одна на пост, `slug` = `rubric_ids` из стандарта);
+  * `category` — категория поста (одна на пост, `slug` = `category_ids` из стандарта);
+  * `keywords` — ключевые слова из словаря (`slug` = `keyword_ids`);
+  * `keywordsRaw` — сырые ключевые слова (массив строк), аналог `keywords_raw` из стандарта.
   * `contentFiles` — соответствие языков и markdown-файлов.
 * Метаданные не парсятся из Markdown — контент и мета разделены намеренно.
 

--- a/personal-site/lib/blog/blog.base.ts
+++ b/personal-site/lib/blog/blog.base.ts
@@ -23,11 +23,16 @@ export const baseBlogPosts: BlogPostBase[] = [
     originalLink:
       "https://antonkolhonen.com/trenirovki/eta-istoriya-pro-odnogo-cheloveka",
     wordpressId: 3026,
-    categories: [
-      { title: "Психология", slug: "psihologiya" },
-      { title: "Тренировки", slug: "trenirovki" },
-    ],
-    tags: [],
+    rubric: {
+      label: "Установка на преодоление",
+      slug: "rubric:orientation-toward-overcoming",
+    },
+    category: {
+      label: "Преодоление",
+      slug: "category:overcoming",
+    },
+    keywords: [{ label: "Existential choice", slug: "keyword:existential-choice" }],
+    keywordsRaw: ["успех", "преодоление", "мотивация"],
     coverImage: {
       src: "/images/posts/maxresdefault.jpg",
       width: 1280,

--- a/personal-site/lib/blog/types.ts
+++ b/personal-site/lib/blog/types.ts
@@ -2,7 +2,7 @@ export type BlogPostStatus = "publish" | "draft" | "private";
 export type Lang = "ru" | "en" | "de" | "fi" | "cn";
 
 export interface BlogTaxonomy {
-  title: string;
+  label: string;
   slug: string;
 }
 
@@ -20,8 +20,10 @@ export interface BlogPostBase {
   publishedAt: string;
   author: string;
   status: BlogPostStatus;
-  categories: BlogTaxonomy[];
-  tags: BlogTaxonomy[];
+  rubric: BlogTaxonomy;
+  category: BlogTaxonomy;
+  keywords: BlogTaxonomy[];
+  keywordsRaw: string[];
   coverImage?: BlogImage;
   originalLink?: string;
   wordpressId?: number;


### PR DESCRIPTION
### Motivation
- Упростить и зафиксировать структуру таксономий: одна рубрика и одна категория на пост вместо массивов. 
- Убрать устаревшее поле `tags` и привести метаданные в соответствие со стандартами `knowledge-core`, добавив управляемые `keywords` и сырые `keywordsRaw`.

### Description
- Обновлены типы в `personal-site/lib/blog/types.ts`: `BlogTaxonomy.title` переименовано в `label`, `categories` и `tags` заменены на `rubric: BlogTaxonomy`, `category: BlogTaxonomy`, `keywords: BlogTaxonomy[]` и `keywordsRaw: string[]` в `BlogPostBase`.
- Обновлён пример метаданных в `personal-site/lib/blog/blog.base.ts`: удалены массивы `categories` и поле `tags`, добавлены `rubric`, `category`, `keywords` и `keywordsRaw` для поста `eta-istoriya-pro-odnogo-cheloveka`.
- Обновлена документация в `personal-site/lib/blog/README.md`: инструкции по заполнению метаданных заменены на `rubric`/`category`/`keywords`/`keywordsRaw` и добавлено примечание, что `slug` соответствует `*_ids` (например, `rubric` → `rubric_ids`, `category` → `category_ids`, `keywords` → `keyword_ids`).

### Testing
- Автоматические тесты не запускались, изменения касаются типов, данных и документации и не требовали прогонов тестов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692c716f4883218cb268d5f3601327)