### PR TITLE
Нормализация Accept-Language — выбрать первый поддерживаемый язык и сохранить zh→cn

### DIFF
--- a/personal-site/lib/blog/blog.i18n.ts
+++ b/personal-site/lib/blog/blog.i18n.ts
@@ -13,11 +13,24 @@ export function normalizeLang(value?: string | null): Lang | undefined {
   }
 
   const normalized = value.toLowerCase();
-  const base = normalized.split("-")[0];
+  const candidates = normalized.split(",");
 
-  if (base === "zh") {
-    return "cn";
+  for (const candidate of candidates) {
+    const primary = candidate.split(";")[0]?.trim();
+    if (!primary) {
+      continue;
+    }
+
+    const base = primary.split("-")[0];
+
+    if (base === "zh") {
+      return "cn";
+    }
+
+    if (isLang(base)) {
+      return base;
+    }
   }
 
-  return isLang(base) ? base : undefined;
+  return undefined;
 }


### PR DESCRIPTION
### Motivation
- Обработать заголовок `Accept-Language`, который может содержать список языков и `q`-параметры.
- Выбирать первый поддерживаемый язык из списка (например, `en` из `en-US,en;q=0.9,ru;q=0.8`).
- Сохранить текущую семантику `zh → cn` для китайского языка.

### Description
- Обновлён `normalizeLang` в `personal-site/lib/blog/blog.i18n.ts` для парсинга значения через разделение по запятым и итерации по каждому кандидату.
- Для каждого элемента берётся часть до `;` и выполняется `trim`, затем первичный тег приводится к форме `xx-YY → xx` через `split('-')[0]`.
- Проверяется поддерживается ли язык через `isLang`, и при первом совпадении возвращается этот язык.
- Сохраняется специальная обработка `base === "zh"` чтобы возвращать `"cn"`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccc3cedf88321926fd549d483ef80)