### PR TITLE
Вынести локали блога и сортировка постов по дате

### DIFF
--- a/personal-site/app/[lang]/blog/[slug]/page.tsx
+++ b/personal-site/app/[lang]/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { getPostByLangAndSlug } from "../../../../lib/blog/blog.data";
-import { isLang } from "../../../../lib/blog/blog.i18n";
+import { blogLocaleByLang, isLang } from "../../../../lib/blog/blog.i18n";
 import { getMetadataBase } from "../../../../lib/blog/blog.metadata";
 
 interface BlogPostPageProps {
@@ -75,13 +75,14 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
   const contentHtml = post.contentHtml.trim();
   const fallbackText = post.content.trim();
+  const locale = blogLocaleByLang[post.lang];
 
   return (
     <main className="page">
       <article className="blog-post">
         <header className="blog-post__header">
           <p className="blog-post__meta">
-            {new Date(post.publishedAt).toLocaleDateString("ru-RU")} · {post.author}
+            {new Date(post.publishedAt).toLocaleDateString(locale)} · {post.author}
           </p>
           <h1 className="blog-post__title">{post.titles[lang]}</h1>
           {post.coverImage ? (

--- a/personal-site/app/[lang]/blog/page.tsx
+++ b/personal-site/app/[lang]/blog/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getPostsIndexForLang } from "../../../lib/blog/blog.data";
-import { isLang, supportedLangs } from "../../../lib/blog/blog.i18n";
+import { blogLocaleByLang, isLang, supportedLangs } from "../../../lib/blog/blog.i18n";
 import { getMetadataBase } from "../../../lib/blog/blog.metadata";
 import type { Lang } from "../../../lib/blog/types";
 
@@ -47,14 +47,6 @@ const blogCopyByLang: Record<Lang, { heading: string; subheading: string; readMo
     subheading: "来自 WordPress 的首批材料。",
     readMore: "阅读全文 →"
   }
-};
-
-const blogLocaleByLang: Record<Lang, string> = {
-  ru: "ru-RU",
-  en: "en-US",
-  de: "de-DE",
-  fi: "fi-FI",
-  cn: "zh-CN"
 };
 
 export const runtime = "nodejs";

--- a/personal-site/lib/blog/blog.data.ts
+++ b/personal-site/lib/blog/blog.data.ts
@@ -79,7 +79,7 @@ export async function getPostsIndexForLang(lang: Lang): Promise<BlogPostSummary[
   const { readFile } = await import("fs/promises");
   const posts = baseBlogPosts.filter((entry) => entry.contentFiles?.[lang]);
 
-  return Promise.all(
+  const summaries = await Promise.all(
     posts.map(async (post) => {
       const { excerpt, frontmatter } = await buildPostExcerpt(post, lang, readFile);
       const frontmatters = await buildFrontmatterMap(post, readFile);
@@ -93,6 +93,10 @@ export async function getPostsIndexForLang(lang: Lang): Promise<BlogPostSummary[
         frontmatter,
       };
     })
+  );
+
+  return summaries.sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
   );
 }
 

--- a/personal-site/lib/blog/blog.i18n.ts
+++ b/personal-site/lib/blog/blog.i18n.ts
@@ -2,6 +2,13 @@ import { Lang } from "./types";
 
 export const supportedLangs: Lang[] = ["ru", "en", "de", "fi", "cn"];
 export const defaultLang: Lang = "ru";
+export const blogLocaleByLang: Record<Lang, string> = {
+  ru: "ru-RU",
+  en: "en-US",
+  de: "de-DE",
+  fi: "fi-FI",
+  cn: "zh-CN",
+};
 
 export function isLang(value: string): value is Lang {
   return supportedLangs.includes(value as Lang);


### PR DESCRIPTION
### Motivation
- ✨ Упростить локализацию дат в блоге и убрать жёсткие значения локали в компонентах страниц, используя единый словарь локалей.
- Обеспечить корректный порядок постов — самые свежие должны отображаться первыми.

### Description
- Добавлен `blogLocaleByLang` в `lib/blog/blog.i18n.ts` с соответствиями языков и локалей.
- Заменена жёсткая локаль на использование `blogLocaleByLang` в `app/[lang]/blog/page.tsx` и `app/[lang]/blog/[slug]/page.tsx` при форматировании дат.
- В `lib/blog/blog.data.ts` функция `getPostsIndexForLang` теперь собирает массив сводок и возвращает его, отсортированным по `publishedAt` в порядке убывания с использованием `new Date(...).getTime()`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccd0d91988321a2e507e729673678)