### PR TITLE
Обновить схему frontmatter блога (administrative / descriptive / structural)

### DIFF
--- a/personal-site/lib/blog/README.md
+++ b/personal-site/lib/blog/README.md
@@ -46,7 +46,8 @@
 * Общие метаданные хранятся централизованно в `blog.base.ts`.
 * Для постов поддерживаются:
 
-* `id`, `slug`, `title`, `preview`, `seoLead` — берутся из frontmatter (по языкам).
+* `id`, `title`, `preview`, `seoLead` — берутся из frontmatter (по языкам).
+* `slug` для маршрутов строится из `administrative.id`.
 * `rubric` — рубрика поста (одна на пост, `slug` = `rubric_ids` из стандарта).
 * `category` — категория поста (одна на пост, `slug` = `category_ids` из стандарта).
 * `keywords` — ключевые слова из словаря (`slug` = `keyword_ids`).
@@ -54,6 +55,36 @@
 * `contentFiles` — соответствие языков и markdown-файлов.
 * Метаданные из frontmatter приоритетны для `id`, `status`, `date_ymd`, `taxonomy`, `title`, `preview`, `seoLead`.
 * Переводы рубрик, категорий и ключевых слов лежат в `lib/blog/taxonomy.ts` (label/description/postulate).
+
+#### 🧩 Структура frontmatter (актуальная схема)
+
+Frontmatter всегда содержит вложенные блоки:
+
+```yaml
+---
+type: post
+administrative:
+  id: some-post-id
+  authors:
+    - Anton
+  date_ymd: 2026-01-17
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "Заголовок поста"
+  preview: "Короткий анонс."
+  seoLead: "SEO-лид."
+  taxonomy:
+    rubric_ids: ["rubric:shadow-and-light"]
+    category_ids: ["category:shadow-and-light"]
+    keyword_ids: ["keyword:ambivalence"]
+    keywords_raw: ["внутренний конфликт"]
+structural:
+  external_links: []
+  document_links: []
+---
+```
 
 ### 🔹 i18n логика
 

--- a/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/cn.md
+++ b/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/cn.md
@@ -1,19 +1,25 @@
 ---
 type: post
-id: eta-istoriya-pro-odnogo-cheloveka
-slug: zhe-shi-yi-ge-ren-de-gu-shi
-authors:
-  - Anton
-date_ymd: 2016-05-16
-status: publish
-title: "这是关于一个人的故事"
-preview: "关于成功欲望被考验的一则寓言。"
-seoLead: "一个提醒：真正的成功来自于你对它的渴望像对生命一样强烈。"
-taxonomy:
-  rubric_ids: ["rubric:orientation-toward-overcoming"]
-  category_ids: ["category:overcoming"]
-  keyword_ids: ["keyword:existential-choice"]
-  keywords_raw: ["成功", "克服", "动力"]
+administrative:
+  id: eta-istoriya-pro-odnogo-cheloveka
+  authors:
+    - Anton
+  date_ymd: 2016-05-16
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "这是关于一个人的故事"
+  preview: "关于成功欲望被考验的一则寓言。"
+  seoLead: "一个提醒：真正的成功来自于你对它的渴望像对生命一样强烈。"
+  taxonomy:
+    rubric_ids: ["rubric:orientation-toward-overcoming"]
+    category_ids: ["category:overcoming"]
+    keyword_ids: ["keyword:existential-choice"]
+    keywords_raw: ["成功", "克服", "动力"]
+structural:
+  external_links: []
+  document_links: []
 ---
 
 

--- a/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/de.md
+++ b/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/de.md
@@ -1,19 +1,25 @@
 ---
 type: post
-id: eta-istoriya-pro-odnogo-cheloveka
-slug: diese-geschichte-uber-eine-person
-authors:
-  - Anton
-date_ymd: 2016-05-16
-status: publish
-title: "Diese Geschichte handelt von einer Person"
-preview: "Eine Parabel darüber, wie der Wunsch nach Erfolg auf die Probe gestellt wird."
-seoLead: "Eine Geschichte, die daran erinnert, dass echter Erfolg kommt, wenn man ihn so sehr will wie das Leben."
-taxonomy:
-  rubric_ids: ["rubric:orientation-toward-overcoming"]
-  category_ids: ["category:overcoming"]
-  keyword_ids: ["keyword:existential-choice"]
-  keywords_raw: ["Erfolg", "Überwindung", "Motivation"]
+administrative:
+  id: eta-istoriya-pro-odnogo-cheloveka
+  authors:
+    - Anton
+  date_ymd: 2016-05-16
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "Diese Geschichte handelt von einer Person"
+  preview: "Eine Parabel darüber, wie der Wunsch nach Erfolg auf die Probe gestellt wird."
+  seoLead: "Eine Geschichte, die daran erinnert, dass echter Erfolg kommt, wenn man ihn so sehr will wie das Leben."
+  taxonomy:
+    rubric_ids: ["rubric:orientation-toward-overcoming"]
+    category_ids: ["category:overcoming"]
+    keyword_ids: ["keyword:existential-choice"]
+    keywords_raw: ["Erfolg", "Überwindung", "Motivation"]
+structural:
+  external_links: []
+  document_links: []
 ---
 
 

--- a/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/en.md
+++ b/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/en.md
@@ -1,19 +1,25 @@
 ---
 type: post
-id: eta-istoriya-pro-odnogo-cheloveka
-slug: this-story-about-one-person
-authors:
-  - Anton
-date_ymd: 2016-05-16
-status: publish
-title: "This story is about one person"
-preview: "A parable about how the desire for success is tested."
-seoLead: "A story reminding that real success comes when you want it as much as you want to live."
-taxonomy:
-  rubric_ids: ["rubric:orientation-toward-overcoming"]
-  category_ids: ["category:overcoming"]
-  keyword_ids: ["keyword:existential-choice"]
-  keywords_raw: ["success", "overcoming", "motivation"]
+administrative:
+  id: eta-istoriya-pro-odnogo-cheloveka
+  authors:
+    - Anton
+  date_ymd: 2016-05-16
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "This story is about one person"
+  preview: "A parable about how the desire for success is tested."
+  seoLead: "A story reminding that real success comes when you want it as much as you want to live."
+  taxonomy:
+    rubric_ids: ["rubric:orientation-toward-overcoming"]
+    category_ids: ["category:overcoming"]
+    keyword_ids: ["keyword:existential-choice"]
+    keywords_raw: ["success", "overcoming", "motivation"]
+structural:
+  external_links: []
+  document_links: []
 ---
 
 

--- a/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/fi.md
+++ b/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/fi.md
@@ -1,19 +1,25 @@
 ---
 type: post
-id: eta-istoriya-pro-odnogo-cheloveka
-slug: tama-tarina-yhdesta-ihmisesta
-authors:
-  - Anton
-date_ymd: 2016-05-16
-status: publish
-title: "Tämä tarina kertoo yhdestä ihmisestä"
-preview: "Vertaus siitä, miten menestyksen halu joutuu koetukselle."
-seoLead: "Tarina siitä, että todellinen menestys syntyy, kun sitä haluaa yhtä paljon kuin elää."
-taxonomy:
-  rubric_ids: ["rubric:orientation-toward-overcoming"]
-  category_ids: ["category:overcoming"]
-  keyword_ids: ["keyword:existential-choice"]
-  keywords_raw: ["menestys", "ylittäminen", "motivaatio"]
+administrative:
+  id: eta-istoriya-pro-odnogo-cheloveka
+  authors:
+    - Anton
+  date_ymd: 2016-05-16
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "Tämä tarina kertoo yhdestä ihmisestä"
+  preview: "Vertaus siitä, miten menestyksen halu joutuu koetukselle."
+  seoLead: "Tarina siitä, että todellinen menestys syntyy, kun sitä haluaa yhtä paljon kuin elää."
+  taxonomy:
+    rubric_ids: ["rubric:orientation-toward-overcoming"]
+    category_ids: ["category:overcoming"]
+    keyword_ids: ["keyword:existential-choice"]
+    keywords_raw: ["menestys", "ylittäminen", "motivaatio"]
+structural:
+  external_links: []
+  document_links: []
 ---
 
 

--- a/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/ru.md
+++ b/personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/ru.md
@@ -1,19 +1,25 @@
 ---
 type: post
-id: eta-istoriya-pro-odnogo-cheloveka
-slug: eta-istoriya-pro-odnogo-cheloveka
-authors:
-  - Anton
-date_ymd: 2016-05-16
-status: publish
-title: "Эта история про одного человека"
-preview: "История о том, как желание добиться успеха проверяется на прочность."
-seoLead: "Притча о том, что настоящий успех приходит, когда ты хочешь его так же, как хочешь жить."
-taxonomy:
-  rubric_ids: ["rubric:orientation-toward-overcoming"]
-  category_ids: ["category:overcoming"]
-  keyword_ids: ["keyword:existential-choice"]
-  keywords_raw: ["успех", "преодоление", "мотивация"]
+administrative:
+  id: eta-istoriya-pro-odnogo-cheloveka
+  authors:
+    - Anton
+  date_ymd: 2016-05-16
+  status: publish
+  channels:
+    - personal_site_blog
+descriptive:
+  title: "Эта история про одного человека"
+  preview: "История о том, как желание добиться успеха проверяется на прочность."
+  seoLead: "Притча о том, что настоящий успех приходит, когда ты хочешь его так же, как хочешь жить."
+  taxonomy:
+    rubric_ids: ["rubric:orientation-toward-overcoming"]
+    category_ids: ["category:overcoming"]
+    keyword_ids: ["keyword:existential-choice"]
+    keywords_raw: ["успех", "преодоление", "мотивация"]
+structural:
+  external_links: []
+  document_links: []
 ---
 
 

--- a/personal-site/lib/blog/types.ts
+++ b/personal-site/lib/blog/types.ts
@@ -35,17 +35,31 @@ export interface BlogTaxonomyIds {
   keywords_raw?: string[];
 }
 
-export interface BlogPostFrontmatter {
-  type?: "post";
+export interface BlogPostFrontmatterAdministrative {
   id?: string;
-  slug?: string;
   authors?: string[];
   date_ymd?: string;
   status?: BlogPostStatus;
+  channels?: string[];
+}
+
+export interface BlogPostFrontmatterDescriptive {
   title?: string;
   preview?: string;
   seoLead?: string;
   taxonomy?: BlogTaxonomyIds;
+}
+
+export interface BlogPostFrontmatterStructural {
+  external_links?: string[];
+  document_links?: string[];
+}
+
+export interface BlogPostFrontmatter {
+  type?: "post";
+  administrative: BlogPostFrontmatterAdministrative;
+  descriptive: BlogPostFrontmatterDescriptive;
+  structural: BlogPostFrontmatterStructural;
 }
 
 export interface BlogTaxonomyLocalized {


### PR DESCRIPTION
### Motivation

- ✨ Централизовать и сделать frontmatter явной вложенной структурой для блога (`administrative`, `descriptive`, `structural`) чтобы упростить обработку метаданных и унифицировать поля (id, authors, date_ymd, status, taxonomy и т.д.).
- 🛣️ Обеспечить, что маршруты/slug'и и логика резолва локализованных полей используют стабильный `administrative.id` как источник истины для идентификатора поста.

### Description

- Обновлены типы в `personal-site/lib/blog/types.ts`: добавлены `BlogPostFrontmatterAdministrative`, `BlogPostFrontmatterDescriptive`, `BlogPostFrontmatterStructural` и `BlogPostFrontmatter` со вложенной схемой `administrative / descriptive / structural`.
- Переработан парсинг и резолв мета-полей в `personal-site/lib/blog/blog.data.ts`: теперь используются `administrative.status` и `administrative.date_ymd` для статуса и даты, `descriptive.taxonomy` для таксономии и `descriptive.title/preview/seoLead` для локализаций, а `administrative.id` — как канонический идентификатор/slug для маршрутов и поиска.
- Приведены существующие frontmatter-файлы поста `eta-istoriya-pro-odnogo-cheloveka` (все языки) к новой структуре (`personal-site/lib/blog/posts/eta-istoriya-pro-odnogo-cheloveka/{ru,en,de,fi,cn}.md`).
- Обновлена документация в `personal-site/lib/blog/README.md` с примером и описанием актуальной схемы frontmatter.

### Testing

- Автоматические тесты не запускались, изменений в тестовой инфраструктуре нет.
- Кодовые изменения ограничены типами, парсингом frontmatter и статическими markdown-файлами; ручной рефакторинг и проверка файлов завершены локально перед коммитом.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ccfeb2540832184b1790b200de74c)