### PR TITLE
✨ Hero: фикс заголовка — одна строка и поверх логотипа

### DIFF
--- a/detai-site/components/sections/Hero.tsx
+++ b/detai-site/components/sections/Hero.tsx
@@ -14,9 +14,11 @@ export default function Hero() {
       fullWidth
     >
       <div className="relative z-20 w-full max-w-[48rem] md:max-w-[52rem]">
-        <HeroHeadingTitle className="text-[color:rgb(var(--hero-text))]">
-          Dialectical Existential Therapy × DETai.
-        </HeroHeadingTitle>
+        <div className="relative z-30 w-max whitespace-nowrap">
+          <HeroHeadingTitle className="text-[color:rgb(var(--hero-text))]">
+            Dialectical Existential Therapy × DETai.
+          </HeroHeadingTitle>
+        </div>
         <p className="mt-4 text-lg leading-snug text-[color:var(--hero-subtitle)] md:text-xl lg:text-2xl">
           Новый формат психотерапии
         </p>


### PR DESCRIPTION
### Motivation
- Сделать заголовок Hero `Dialectical Existential Therapy × DETai.` в одну строку и разместить его поверх правой части сцены, не меняя текущую раскладку.

### Description
- Обёрнут `HeroHeadingTitle` в дополнительный контейнер `div` с классами `w-max whitespace-nowrap z-30` в `detai-site/components/sections/Hero.tsx`, чтобы предотвратить перенос и обеспечить наложение над правым блоком.

### Testing
- Автоматически запущен dev-сервер командой `npm run dev` и выполнён скрипт Playwright для создания скриншота главной страницы, оба шага успешно завершились.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fdb5148248321b31784d5cb62e7c3)