### PR TITLE
Исправить дату публикации в переводах поста

### DIFF
--- a/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/cn.md
+++ b/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/cn.md
@@ -4,7 +4,7 @@ administrative:
   id: sila-i-svet-haus-i-mrak
   authors:
     - Anton Kolhonen
-  date_ymd: 2026-01-17
+  date_ymd: 2016-06-23
   status: publish
   channels:
     - personal_site_blog

--- a/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/de.md
+++ b/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/de.md
@@ -4,7 +4,7 @@ administrative:
   id: sila-i-svet-haus-i-mrak
   authors:
     - Anton Kolhonen
-  date_ymd: 2026-01-17
+  date_ymd: 2016-06-23
   status: publish
   channels:
     - personal_site_blog

--- a/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/en.md
+++ b/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/en.md
@@ -4,7 +4,7 @@ administrative:
   id: sila-i-svet-haus-i-mrak
   authors:
     - Anton Kolhonen
-  date_ymd: 2026-01-17
+  date_ymd: 2016-06-23
   status: publish
   channels:
     - personal_site_blog

--- a/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/fi.md
+++ b/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/fi.md
@@ -4,7 +4,7 @@ administrative:
   id: sila-i-svet-haus-i-mrak
   authors:
     - Anton Kolhonen
-  date_ymd: 2026-01-17
+  date_ymd: 2016-06-23
   status: publish
   channels:
     - personal_site_blog

--- a/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/ru.md
+++ b/personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/ru.md
@@ -4,7 +4,7 @@ administrative:
   id: sila-i-svet-haus-i-mrak
   authors:
     - Anton Kolhonen
-  date_ymd: 2026-01-17
+  date_ymd: 2016-06-23
   status: publish
   channels:
     - personal_site_blog


### PR DESCRIPTION
### Motivation
- 📅 Привести `administrative.date_ymd` в переводах поста `sila-i-svet-haus-i-mrak` к правильной дате-источнику `2016-06-23`, чтобы соответствовать `publishedAt` в `personal-site/lib/blog/blog.base.ts`.

### Description
- Обновлены поля `administrative.date_ymd` в файлах `personal-site/lib/blog/posts/sila-i-svet-haus-i-mrak/{ru,en,de,fi,cn}.md` с `2026-01-17` на `2016-06-23` (5 файлов).

### Testing
- Автоматические тесты не запускались (изменение носит корректирующий характер и не требует тестов).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697116f29c648321beb42c75d1f2f619)