### PR TITLE
Добавить правило о запрете бинарных обложек

### DIFF
--- a/packages/static-data/post_documents/post_creation_prompt.md
+++ b/packages/static-data/post_documents/post_creation_prompt.md
@@ -132,6 +132,12 @@ structural:
    - `contentFiles` для всех языков
 6. Обложка:
    - если пост общий для обоих сайтов — допускается единая обложка в `personal-site/public/images/posts/` + абсолютная ссылка для `detai-site` (см. `post_images_policy.md`).
+   6.1. Запрет на бинарные файлы:
+     - Бинарные файлы (изображения) **не добавляем** в репозиторий. Если обложка уже есть в `personal-site/public/images/posts/`, то:
+       - для `personal-site` используйте локальный путь `"/images/posts/<file>"`;
+       - для `detai-site` укажите **абсолютный URL** на личный сайт в `coverImage.src`;
+       - обязательно заполните `coverImage` в `personal-site/lib/blog/blog.base.ts` и/или `detai-site/lib/blog/blog.base.ts` по каналам поста.
+     - Правило применяется только если обложка уже существует; иначе не упоминаем её в описании поста.
 
 ---
 


### PR DESCRIPTION
### Motivation
- ✨ Уточнить политику обработки обложек, чтобы запретить хранение бинарных изображений в репозитории и задать правило использования уже существующих файлов в `personal-site/public/images/posts/`.

### Description
- Добавлен подпункт `6.1. Запрет на бинарные файлы` в `packages/static-data/post_documents/post_creation_prompt.md`, который запрещает добавление бинарных изображений и предписывает использовать локальный путь `"/images/posts/<file>"` для `personal-site`, указывать абсолютный URL в `coverImage.src` для `detai-site`, а также обязательно заполнять `coverImage` в `personal-site/lib/blog/blog.base.ts` и/или `detai-site/lib/blog/blog.base.ts` по каналам поста; правило применяется только если обложка уже существует.

### Testing
- Автоматические тесты не запускались, изменения относятся только к документации.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712c1b71f48321aba47fbfdf62f860)