### PR TITLE
Уточнить отступы и тон превью в шапке блога

### DIFF
--- a/detai-site/components/blog/BlogPostRenderer.tsx
+++ b/detai-site/components/blog/BlogPostRenderer.tsx
@@ -34,7 +34,7 @@ export default function BlogPostRenderer({
           showRubric={showRubric}
           showCategory={showCategory}
         />
-        <Section variant="light" containerClassName="px-1 md:px-10">
+        <Section variant="light" containerClassName="px-0.5 md:px-8" fullWidth>
           <article className="flex flex-col gap-6 md:gap-8">
             {contentHtml ? (
               <div

--- a/detai-site/components/blog/PostHeader.tsx
+++ b/detai-site/components/blog/PostHeader.tsx
@@ -42,11 +42,12 @@ export default function PostHeader({
     <Section
       variant="light"
       className="border-b border-accentVar/20"
-      containerClassName="px-1 md:px-10"
+      containerClassName="px-0.5 md:px-8"
+      fullWidth
     >
       <div className="flex flex-col gap-4">
         {coverLayout === "landscape" && post.coverImage ? (
-          <div className="w-full md:max-w-4xl mx-[-0.25rem] md:mx-0">
+          <div className="w-full md:max-w-4xl mx-[-0.125rem] md:mx-0">
             <div className="overflow-hidden rounded-3xl bg-accentVar/10 shadow-sm">
               <div className="aspect-[4/3] overflow-hidden md:aspect-[16/9]">
                 <img
@@ -77,7 +78,7 @@ export default function PostHeader({
               {previewText ? (
                 <BodyText
                   variant="sectionDefaultOnLight"
-                  className="max-w-2xl text-mobile-small md:text-lg md:leading-relaxed"
+                  className="max-w-2xl text-mobile-small md:text-lg md:leading-relaxed text-muted md:text-fg"
                 >
                   {previewText}
                 </BodyText>


### PR DESCRIPTION
### Motivation
- Убрать слишком широкие мобильные поля у блоков статьи и шапки, чтобы секции могли быть full-bleed с более узким внутренним отступом (`max-w-mobile` переставал доминировать). 
- Сделать текст превью менее контрастным на мобильных (мягкий серый) с восстановлением обычного цвета на десктопе для читаемости. 
- Подогнать отрицательный `mx` у ландшафтной обложки так, чтобы изображение «выползало» ровно на величину нового паддинга и отступы были симметричны слева/справа.

### Description
- В `detai-site/components/blog/PostHeader.tsx` секции шапки установлено `fullWidth` и изменён `containerClassName` с `px-1 md:px-10` на `px-0.5 md:px-8` для более узких полей; у landscape-обложки `mx-[-0.25rem]` заменён на `mx-[-0.125rem]` для соответствия новым паддингам. 
- В том же файле к превью добавлен класс `text-muted md:text-fg`, чтобы на мобильных отображался более мягкий серый оттенок, на десктопе — обычный цвет. 
- В `detai-site/components/blog/BlogPostRenderer.tsx` секция контента поста также сделана `fullWidth` с `containerClassName=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e1403bac832199f3afb966275907)