### PR TITLE
Исправить путь аватара Anton Kolhonen и удалить бинарный файл

### DIFF
--- a/detai-site/components/blog/BlogPostRenderer.tsx
+++ b/detai-site/components/blog/BlogPostRenderer.tsx
@@ -34,8 +34,12 @@ export default function BlogPostRenderer({
           showRubric={showRubric}
           showCategory={showCategory}
         />
-        <Section variant="light" containerClassName="px-1 md:px-10">
-          <article className="flex flex-col gap-6 md:gap-8">
+        <Section
+          variant="light"
+          fullWidth
+          containerClassName="px-0 md:px-10 md:max-w-6xl"
+        >
+          <article className="flex flex-col gap-6 px-2 md:gap-8 md:px-0">
             {contentHtml ? (
               <div
                 className="space-y-4 text-mobile-body text-fg md:text-lg md:leading-relaxed [&_a]:text-accentVar [&_a]:underline [&_a]:decoration-accentVar/40 [&_a]:underline-offset-4"

--- a/detai-site/components/blog/PostHeader.tsx
+++ b/detai-site/components/blog/PostHeader.tsx
@@ -7,6 +7,7 @@ import { blogLocaleByLang } from "@/lib/blog/blog.i18n";
 import { formatBlogDate } from "@/lib/blog/blog.utils";
 import { getRubricRouteSlug } from "@/lib/blog/taxonomy";
 import type { BlogPost, BlogCoverLayout, Lang } from "@/lib/blog/types";
+import authorsData from "../../../packages/static-data/authors.json";
 
 import { blogPostCopyByLang } from "./blogPostCopy";
 import PostCoverPortrait from "./PostCoverPortrait";
@@ -34,6 +35,11 @@ export default function PostHeader({
   const readingTimeLabel = `${readingTime} ${copy.minReadLabel}`;
   const authorName = post.author?.trim();
   const authorInitials = getInitials(authorName);
+  const authorMeta = authorName
+    ? authorsData.items.find((author) => author.display_name === authorName)
+    : undefined;
+  const authorRole = authorMeta?.role?.trim();
+  const authorAvatar = authorMeta?.avatar?.trim();
   const category = post.category?.label?.trim() ? post.category : null;
   const categoryHref = category ? `/${lang}/blog?category=${category.slug}` : null;
   const coverLayout = resolveCoverLayout(post.coverLayout, post.coverImage);
@@ -42,11 +48,12 @@ export default function PostHeader({
     <Section
       variant="light"
       className="border-b border-accentVar/20"
-      containerClassName="px-1 md:px-10"
+      fullWidth
+      containerClassName="px-0 md:px-10 md:max-w-6xl"
     >
       <div className="flex flex-col gap-4">
         {coverLayout === "landscape" && post.coverImage ? (
-          <div className="w-full md:max-w-4xl mx-[-0.25rem] md:mx-0">
+          <div className="w-full md:max-w-4xl">
             <div className="overflow-hidden rounded-3xl bg-accentVar/10 shadow-sm">
               <div className="aspect-[4/3] overflow-hidden md:aspect-[16/9]">
                 <img
@@ -67,7 +74,7 @@ export default function PostHeader({
               : "flex flex-col gap-3"
           }
         >
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3 px-2 md:px-0">
             <div className="flex flex-col gap-3">
               <p className="text-[0.65rem] font-medium text-muted md:text-xs">
                 {formattedDate}
@@ -77,7 +84,7 @@ export default function PostHeader({
               {previewText ? (
                 <BodyText
                   variant="sectionDefaultOnLight"
-                  className="max-w-2xl text-mobile-small md:text-lg md:leading-relaxed"
+                  className="max-w-2xl text-mobile-small md:text-base md:leading-relaxed md:text-muted"
                 >
                   {previewText}
                 </BodyText>
@@ -91,10 +98,25 @@ export default function PostHeader({
               >
                 {authorName ? (
                   <div className="flex flex-wrap items-center gap-3">
-                    <div className="flex h-9 w-9 items-center justify-center rounded-full bg-accentVar/10 text-xs font-semibold text-accentVar">
-                      {authorInitials}
+                    {authorAvatar ? (
+                      <img
+                        className="h-10 w-10 rounded-full object-cover"
+                        src={authorAvatar}
+                        alt={authorName}
+                        width={40}
+                        height={40}
+                      />
+                    ) : (
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accentVar/10 text-xs font-semibold text-accentVar">
+                        {authorInitials}
+                      </div>
+                    )}
+                    <div className="flex flex-col">
+                      <p className="text-sm font-semibold text-fg">{authorName}</p>
+                      {authorRole ? (
+                        <p className="text-xs text-muted">{authorRole}</p>
+                      ) : null}
                     </div>
-                    <p className="text-sm font-semibold text-fg">{authorName}</p>
                     <span className="h-4 w-px bg-accentVar/30" aria-hidden />
                     <p className="flex items-center gap-2 text-xs font-medium text-muted md:text-sm">
                       <span aria-hidden>🕒</span>

--- a/packages/static-data/authors.json
+++ b/packages/static-data/authors.json
@@ -6,7 +6,9 @@
       "id": "author:anton-kolhonen",
       "display_name": "Anton Kolhonen",
       "slug": "anton-kolhonen",
-      "type": "person"
+      "type": "person",
+      "role": "Основатель экосистемы",
+      "avatar": "/images/avatars_team_members/avaa_Anton_Kolhonen.webp"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Убрать добавленный бинарный файл из патча и правильно подключить существующее изображение аватара в проекте, чтобы аватар автора корректно отображался в шапке поста.

### Description
- Удалён бинарный файл `detai-site/public/images/avaa_Anton_Kolhonen.webp` из репозитория (удаление в коммите). 
- Исправлен путь к аватару в `packages/static-data/authors.json` на `"/images/avatars_team_members/avaa_Anton_Kolhonen.webp"`.
- Добавлена загрузка данных авторов в `detai-site/components/blog/PostHeader.tsx` (`import authorsData from "../../../packages/static-data/authors.json"`) и реализована логика поиска метаданных автора по `display_name`, отображения `avatar` как `<img>` и вывода `role` при наличии.
- Внесены правки разметки/стилей в `detai-site/components/blog/PostHeader.tsx` и `detai-site/components/blog/BlogPostRenderer.tsx` для корректного рендеринга заголовка и содержимого в обновлённой ширине контейнера.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e3cc517c83218c4153b6003a24c9)