### PR TITLE
Исправить отображение обложки поста на мобильных

### DIFF
--- a/detai-site/components/blog/PostHeader.tsx
+++ b/detai-site/components/blog/PostHeader.tsx
@@ -55,7 +55,7 @@ export default function PostHeader({
         {coverLayout === "landscape" && post.coverImage ? (
           <div className="w-full md:max-w-4xl">
             <div className="overflow-hidden rounded-3xl bg-accentVar/10 shadow-sm">
-              <div className="aspect-[4/3] overflow-hidden md:aspect-[16/9]">
+              <div className="aspect-[16/9] overflow-hidden">
                 <img
                   className="h-full w-full object-cover object-center"
                   src={post.coverImage.src}


### PR DESCRIPTION
### Motivation
- 📱 Исправить обрезание левого и правого края обложки в мобильном виде для поста `eta-istoriya-pro-odnogo-cheloveka`.

### Description
- Внесена одна правка в `detai-site/components/blog/PostHeader.tsx`: заменил контейнер с `aspect-[4/3] md:aspect-[16/9]` на единое `aspect-[16/9]`, чтобы на мобильных устройствах использовать соотношение сторон 16:9.
- Обёртка с `overflow-hidden` и классы изображения `h-full w-full object-cover object-center` сохранены для корректного заполнения области и центровки изображения.

### Testing
- Запущена команда `npm run dev`, Next.js поднялся и страница успешно скомпилировалась.
- Выполнен Playwright-скрипт, который открыл `http://localhost:3000/ru/blog/eta-istoriya-pro-odnogo-cheloveka` в viewport 390×844 и сохранил скриншот в `artifacts/blog-post-mobile.png`, визуальная проверка прошла успешно.
- Автоматические юнит/интеграционные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975069bdd08832196a2d3e49e25f969)